### PR TITLE
Truncation and extension of handshake messages

### DIFF
--- a/scripts/test-truncating-of-client-hello.py
+++ b/scripts/test-truncating-of-client-hello.py
@@ -1,0 +1,121 @@
+# Author: Hubert Kario, (c) 2015
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+from __future__ import print_function
+import traceback
+import sys
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+        ResetHandshakeHashes, SetMaxRecordSize, pad_handshake
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+        ExpectAlert, ExpectApplicationData, ExpectClose
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+        ExtensionType
+from tlslite.extensions import TLSExtension
+
+def main():
+
+    #
+    # Test if client hello with garbage at the end gets rejected
+    #
+
+    conversations = {}
+
+    # test if server doesn't interpret extensions past extensions length
+    conversation = Connect("localhost", 4433)
+    node = conversation
+    ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
+    node = node.add_child(pad_handshake(ClientHelloGenerator(ciphers,
+                                               extensions={}),
+                                        # empty renegotiation info
+                                        pad=bytearray(b'\xff\x01\x00\x01\x00')))
+    # responding to a malformed client hello is not correct, but tested below
+    node = node.add_child(ExpectServerHello(extensions={}))
+    node.next_sibling = ExpectAlert()
+    node.next_sibling.next_sibling = ExpectClose()
+
+    conversations["extension past extensions"] = conversation
+
+
+    for name, pad_len, pad_byte in [
+                                ("small pad", 1, 0),
+                                ("small pad", 2, 0),
+                                ("small pad", 3, 0),
+                                ("small pad", 1, 0xff),
+                                ("small pad", 2, 0xff),
+                                ("small pad", 3, 0xff),
+                                ("medium pad", 256, 0),
+                                ("big pad", 4096, 0),
+                                ("huge pad", 2**16, 0),
+                                ("small truncate", -1, 0),
+                                ("small truncate", -2, 0),
+                                ("small truncate", -3, 0),
+                                ("small truncate", -4, 0),
+                                ("small truncate", -5, 0),
+                                ("small truncate", -6, 0),
+                                # 7 bytes truncates whole 'extensions' creating
+                                # a valid message
+                                #("small truncate", -7, 0),
+                                ("hello truncate", -8, 0),
+                                ("hello truncate", -9, 0),
+                                ("hello truncate", -10, 0),
+                                ("hello truncate", -11, 0),
+                                ("hello truncate", -12, 0),
+                                ("hello truncate", -13, 0),
+                                ]:
+
+        conversation = Connect("localhost", 4433)
+        node = conversation
+        ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
+        node = node.add_child(pad_handshake(ClientHelloGenerator(ciphers,
+                                                   extensions={ExtensionType.renegotiation_info: None}),
+                                            pad_len, pad_byte))
+        node = node.add_child(ExpectAlert())
+        node.next_sibling = ExpectClose()
+
+        if "pad" in name:
+            conversations[name + ": " + str(pad_len) + " of \"" + str(pad_byte) +
+                          "\" byte padding"] = conversation
+        else:
+            conversations[name + ": " + str(-pad_len) +
+                          " of bytes truncated"] = conversation
+
+    # run the conversation
+    good = 0
+    bad = 0
+
+    for conversation_name in conversations:
+        conversation = conversations[conversation_name]
+
+        print(str(conversation_name) + "...\n")
+
+        runner = Runner(conversation)
+
+        res = True
+        try:
+            runner.run()
+        except:
+            print("Error while processing")
+            print(traceback.format_exc())
+            res = False
+
+        if res:
+            good+=1
+            print("OK")
+        else:
+            bad+=1
+
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-truncating-of-finished.py
+++ b/scripts/test-truncating-of-finished.py
@@ -1,0 +1,106 @@
+# Author: Hubert Kario, (c) 2015
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+from __future__ import print_function
+import traceback
+import sys
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+        ResetHandshakeHashes, pad_handshake, truncate_handshake
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+        ExpectAlert, ExpectApplicationData, ExpectClose
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+        ExtensionType
+
+def main():
+
+    #
+    # Test sending invalid (too short or too long) Finished messages
+    #
+
+    conversations = {}
+
+    conver = Connect("localhost", 4433)
+    node = conver
+    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
+    node = node.add_child(ClientHelloGenerator(ciphers,
+                                               extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectServerHelloDone())
+    node = node.add_child(ClientKeyExchangeGenerator())
+    node = node.add_child(ChangeCipherSpecGenerator())
+    node = node.add_child(pad_handshake(FinishedGenerator(), pad=bytearray(b'\xfa')))
+    #node = node.add_child(ExpectChangeCipherSpec())
+    #node = node.add_child(ExpectFinished())
+
+    #node = node.add_child(AlertGenerator(AlertLevel.warning,
+    #                                     AlertDescription.close_notify))
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+
+    conversations["padded Finished"] = conver
+
+    conver = Connect("localhost", 4433)
+    node = conver
+    #ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+    #           CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
+    node = node.add_child(ClientHelloGenerator(ciphers,
+                                               extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.renegotiation_info:None}))
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectServerHelloDone())
+    node = node.add_child(ClientKeyExchangeGenerator())
+    node = node.add_child(ChangeCipherSpecGenerator())
+    node = node.add_child(truncate_handshake(FinishedGenerator(), 1))
+    #node = node.add_child(ExpectChangeCipherSpec())
+    #node = node.add_child(ExpectFinished())
+
+    #node = node.add_child(AlertGenerator(AlertLevel.warning,
+    #                                     AlertDescription.close_notify))
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+
+    conversations["truncated Finished"] = conver
+
+    # run the conversation
+    good = 0
+    bad = 0
+
+    for conver_name in conversations:
+        conversation = conversations[conver_name]
+        runner = Runner(conversation)
+        print(conver_name + "...")
+
+        res = True
+        try:
+            runner.run()
+        except:
+            print("\n")
+            print("Error while processing")
+            print(traceback.format_exc())
+            res = False
+
+        if res:
+            good+=1
+            print("OK")
+        else:
+            bad+=1
+
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tlsfuzzer_runner.py
+++ b/tests/test_tlsfuzzer_runner.py
@@ -136,3 +136,23 @@ class TestRunner(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             runner.run()
+
+    def test_run_with_expect_node_and_unexpected_message(self):
+        node = mock.MagicMock()
+        node.is_command = mock.Mock(return_value=False)
+        node.is_expect = mock.Mock(return_value=True)
+        node.is_generator = mock.Mock(return_value=False)
+        node.get_all_siblings = mock.Mock(return_value=[node])
+        node.is_match = mock.Mock(return_value=False)
+        node.child = None
+
+        runner = Runner(node)
+        runner.state.msg_sock = mock.MagicMock()
+        msg = (mock.MagicMock(name="header"), mock.MagicMock(name="parsser"))
+        runner.state.msg_sock.recvMessageBlocking = \
+                mock.MagicMock(return_value=msg)
+
+        with self.assertRaises(AssertionError):
+            runner.run()
+
+        runner.state.msg_sock.sock.close.called_once_with()

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -125,8 +125,6 @@ class ExpectServerHello(ExpectHandshake):
         state.handshake_messages.append(srv_hello)
         state.handshake_hashes.update(msg.write())
 
-        # TODO: check if server didn't send extensions we didn't advertise
-
         # check if the message has expected values
         if self.extensions is not None:
             for ext_id in self.extensions:
@@ -135,6 +133,10 @@ class ExpectServerHello(ExpectHandshake):
                 # run extension-specific checker if present
                 if self.extensions[ext_id] is not None:
                     self.extensions[ext_id](state, ext)
+            # not supporting any extensions is valid
+            if srv_hello.extensions is not None:
+                for ext_id in (ext.extType for ext in srv_hello.extensions):
+                    assert ext_id in self.extensions
 
 class ExpectCertificate(ExpectHandshake):
 

--- a/tlsfuzzer/runner.py
+++ b/tlsfuzzer/runner.py
@@ -99,6 +99,8 @@ class Runner(object):
                     node = next((proc for proc in node.get_all_siblings()
                                  if proc.is_match(msg)), None)
                     if node is None:
+                        # since we're aborting, the user can't clean up
+                        self.state.msg_sock.sock.close()
                         raise AssertionError("Unexpected message from peer: " +
                                              str(msg.contentType) + ", " +
                                              str(msg.write()[0]))


### PR DESCRIPTION
Add methods to truncate and pad arbitrary handshake messages.

Adds two scripts to check if truncated Client Hello messages as well as truncated Finished messages are rejected.