### PR TITLE
Fuzzing of MAC values

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tlslite-ng>=0.5.0-beta6
+tlslite-ng>=0.6.0-alpha1

--- a/scripts/test-fuzzed-MAC.py
+++ b/scripts/test-fuzzed-MAC.py
@@ -1,0 +1,98 @@
+# Author: Hubert Kario, (c) 2015
+# Released under Gnu GPL v2.0, see LICENSE file for details
+"""Example MAC value fuzzer"""
+
+from __future__ import print_function
+import traceback
+import sys
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, \
+        fuzz_mac
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+        ExpectAlert, ExpectClose
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription
+
+def main():
+    """check if incorrect MAC hash is rejected by server"""
+    conversations = {}
+
+    for pos, val in [
+                     (-1, 0x01),
+                     (-1, 0xff),
+                     (-2, 0x01),
+                     (-2, 0xff),
+                     (-6, 0x01),
+                     (-6, 0xff),
+                     (-12, 0x01),
+                     (-12, 0xff),
+                     (-20, 0x01),
+                     (-20, 0xff),
+                     # SHA-1 HMAC has just 20 bytes
+                     ]:
+        conversation = Connect("localhost", 4433)
+        node = conversation
+        ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+        node = node.add_child(ClientHelloGenerator(ciphers))
+        node = node.add_child(ExpectServerHello())
+        node = node.add_child(ExpectCertificate())
+        node = node.add_child(ExpectServerHelloDone())
+        node = node.add_child(ClientKeyExchangeGenerator())
+        node = node.add_child(ChangeCipherSpecGenerator())
+        node = node.add_child(FinishedGenerator())
+        node = node.add_child(ExpectChangeCipherSpec())
+        node = node.add_child(ExpectFinished())
+        node = node.add_child(fuzz_mac(ApplicationDataGenerator(
+                                                        b"GET / HTTP/1.0\n\n"),
+                                       xors={pos:val}))
+        node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                          AlertDescription.bad_record_mac))
+#        node.next_sibling = ExpectClose()
+        node = node.add_child(ExpectClose())
+
+        conversations["XOR position " + str(pos) + " with " + str(hex(val))] = \
+                conversation
+
+    # run the conversation
+    good = 0
+    bad = 0
+
+    for conversation_name in conversations:
+        conversation = conversations[conversation_name]
+
+        print(conversation_name + "...")
+
+        runner = Runner(conversation)
+
+        res = True
+        #because we don't want to abort the testing and we are reporting
+        #the errors to the user, using a bare except is OK
+        #pylint: disable=bare-except
+        try:
+            runner.run()
+        except:
+            print("Error while processing")
+            print(traceback.format_exc())
+            res = False
+        #pylint: enable=bare-except
+
+        if res:
+            good+=1
+            print("OK")
+        else:
+            bad+=1
+
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/mocksock.py
+++ b/tests/mocksock.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2015, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+import socket
+import errno
+class MockSocket(socket.socket):
+    def __init__(self, buf, maxRet=None, maxWrite=None, blockEveryOther=False):
+        # current position in read buffer (buf)
+        self.index = 0
+        # read buffer
+        self.buf = buf
+        # write buffer (data sent from application, to be asserted by test)
+        self.sent = []
+        self.closed = False
+        # maximum number of bytes that socket will read/return at a time
+        self.maxRet = maxRet
+        # maximum number of bytes that socket will write at a time
+        self.maxWrite = maxWrite
+        # make socket rise errno.EWOULDBLOCK every other read or write
+        self.blockEveryOther = blockEveryOther
+        # if next read will be blocked
+        self.blockRead = False
+        # if next write will be blocked
+        self.blockWrite = False
+
+    def __repr__(self):
+        return "MockSocket(index={0}, buf={1!r}, sent={2!r})".format(
+                self.index, self.buf, self.sent)
+
+    def recv(self, size):
+        if self.closed:
+            raise ValueError("Read from closed socket")
+
+        # simulate a socket with full buffers, make it rise "Would block"
+        # every other call
+        if self.blockEveryOther:
+            if self.blockRead:
+                self.blockRead = False
+                raise socket.error(errno.EWOULDBLOCK)
+            else:
+                self.blockRead = True
+
+        # return empty array if the caller asked for no data
+        if size == 0:
+            return bytearray(0)
+
+        # limit returned data (if set)
+        # this will cause the socket to return just maxRet bytes, even if it
+        # has more in buf or was asked to return more in this call
+        if self.maxRet is not None and self.maxRet < size:
+            size = self.maxRet
+
+        # don't allow reading past array end
+        if len(self.buf[self.index:]) == 0:
+            raise socket.error(errno.EWOULDBLOCK)
+        # if asked for more than we have prepared, return just as much as we
+        # have
+        elif len(self.buf[self.index:]) < size:
+            ret = self.buf[self.index:]
+            self.index = len(self.buf)
+            return ret
+        # regular call, return as much as was asked for
+        else:
+            ret = self.buf[self.index:self.index+size]
+            self.index+=size
+            return ret
+
+    def send(self, data):
+        if self.closed:
+            raise ValueError("Write to closed socket")
+
+        # simulate a socket with full buffer, raise "Would Block" every other
+        # call
+        if self.blockEveryOther:
+            if self.blockWrite:
+                self.blockWrite = False
+                raise socket.error(errno.EWOULDBLOCK)
+            else:
+                self.blockWrite = True
+
+        # regular write, just append to list of performed writes
+        if self.maxWrite is None or len(data) < self.maxWrite:
+            self.sent.append(data)
+            return len(data)
+
+        # simulate a socket that won't write more data that it can
+        # (e.g. because the simulated buffers are mostly full)
+        self.sent.append(data[:self.maxWrite])
+        return self.maxWrite
+
+    def close(self):
+        self.closed = True

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -247,8 +247,10 @@ class ExpectAlert(Expect):
 
     """Processing TLS Alert message"""
 
-    def __init__(self):
+    def __init__(self, level=None, description=None):
         super(ExpectAlert, self).__init__(ContentType.alert)
+        self.level = level
+        self.description = description
 
     def process(self, state, msg):
         assert msg.contentType == ContentType.alert
@@ -256,6 +258,12 @@ class ExpectAlert(Expect):
 
         alert = Alert()
         alert.parse(parser)
+
+        if self.level is not None:
+            assert alert.level == self.level
+
+        if self.description is not None:
+            assert alert.description == self.description
 
 class ExpectApplicationData(Expect):
 


### PR DESCRIPTION
* add ability to fuzz MAC values in CBC ciphersuites
* add ability to specify exact error codes of Alert messages received 
* add example test case that uses that functionality