### PR TITLE
Add support for testing SSLv2 protocol

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tlslite-ng>=0.6.0-alpha4
+tlslite-ng>=0.6.0-alpha5

--- a/scripts/test-sslv2-connection.py
+++ b/scripts/test-sslv2-connection.py
@@ -1,0 +1,122 @@
+# Author: Hubert Kario, (c) 2015
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+"""Test if server supports any of the SSLv2 ciphers"""
+
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, \
+        ClientMasterKeyGenerator, Close
+from tlsfuzzer.expect import ExpectFinished, ExpectApplicationData, \
+        ExpectServerHello2, ExpectVerify
+
+from tlslite.constants import CipherSuite, AlertLevel, \
+        ExtensionType
+
+def help_msg():
+    """Print usage information"""
+    print("Usage: <script-name> [-h hostname] [-p port]")
+    print(" -h hostname   hostname to connect to, \"localhost\" by default")
+    print(" -p port       port to use for connection, \"4433\" by default")
+    print(" --help        this message")
+
+def main():
+    """Test if the server supports some of the SSLv2 ciphers"""
+    conversations = {}
+    host = "localhost"
+    port = 4433
+
+    argv = sys.argv[1:]
+
+    opts, argv = getopt.getopt(argv, "h:p:", ["help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+    if argv:
+        help_msg()
+        raise ValueError("Unknown options: {0}".format(argv))
+
+    for cipher_id, cipher_name in {
+            CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5:"DES-CBC3-MD5",
+            CipherSuite.SSL_CK_RC4_128_WITH_MD5:"RC4-MD5",
+            CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5:"EXP-RC4-MD5"
+            }.items():
+        # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
+        conversation = Connect(host, port, version=(0, 2))
+        node = conversation
+        ciphers = [CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5,
+                   CipherSuite.SSL_CK_RC4_128_WITH_MD5,
+                   CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5]
+
+        node = node.add_child(ClientHelloGenerator(ciphers,
+                                                   version=(0, 2),
+                                                   ssl2=True))
+        node = node.add_child(ExpectServerHello2())
+        node = node.add_child(ClientMasterKeyGenerator(cipher=cipher_id))
+        node = node.add_child(FinishedGenerator())  # serves as a CCS
+        # ExpectVerify could be be before FinishedGenerator, if the latter
+        # didn't serve double duty as a CCS
+        node = node.add_child(ExpectVerify())
+        node = node.add_child(ExpectFinished(version=(0, 2)))
+        node = node.add_child(ApplicationDataGenerator(
+            bytearray(b"GET / HTTP/1.0\n\n")))
+        node = node.add_child(ExpectApplicationData())
+        node = node.add_child(Close())
+
+        conversations["Connect with SSLv2 {0}"
+                      .format(cipher_name)] = conversation
+
+    good = 0
+    bad = 0
+
+    for conversation_name, conversation in conversations.items():
+        print("{0} ...".format(conversation_name))
+
+        runner = Runner(conversation)
+
+        res = True
+        try:
+            runner.run()
+        except:
+            print("Error while processing")
+            print(traceback.format_exc())
+            print("")
+            res = False
+
+        if res:
+            good+=1
+            print("OK\n")
+        else:
+            bad+=1
+
+    print("Note: This test verifies that an implementation implements and")
+    print("      will negotiate SSLv2 protocol. This is a BAD configuration.")
+    print("      SSLv2 was officially deprecated (MUST NOT use) in 2011, see")
+    print("      RFC 6176.")
+    print("      It is left here only to verify that the tlslite-ng")
+    print("      implementation is correct, so tests for disablement of SSLv2")
+    print("      are sane.")
+    print("      For same reason, if any of the connections succeeds, the exit")
+    print("      code from this script will be 1 (i.e. 'failure')")
+    print("")
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+
+    if good > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-sslv2-force-cipher-3des.py
+++ b/scripts/test-sslv2-force-cipher-3des.py
@@ -1,0 +1,148 @@
+# Author: Hubert Kario, (c) 2015
+# Released under Gnu GPL v2.0, see LICENSE file for details
+"""Forcing 3DES ciphers in SSLv2"""
+
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+        ClientMasterKeyGenerator, Close
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, \
+        ExpectAlert, ExpectClose, ExpectApplicationData, ExpectServerHello2, \
+        ExpectVerify, ExpectSSL2Alert
+
+from tlslite.constants import CipherSuite, AlertLevel, \
+        ExtensionType, SSL2ErrorDescription
+
+def help_msg():
+    """Usage information"""
+    print("Usage: <script-name> [-h hostname] [-p port]")
+    print(" -h hostname   hostname to connect to, \"localhost\" by default")
+    print(" -p port       port to use for connection, \"4433\" by default")
+    print(" --help        this message")
+
+def main():
+    """
+    Test if the server will not accept cipher forcing from client
+
+    client forces 3DES
+    """
+    conversations = {}
+    host = "localhost"
+    port = 4433
+
+    argv = sys.argv[1:]
+
+    opts, argv = getopt.getopt(argv, "h:p:", ["help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+    if argv:
+        help_msg()
+        raise ValueError("Unknown options: {0}".format(argv))
+
+    for prot_vers, proto_name in {
+            (0, 2):"SSLv2",
+            (3, 0):"SSLv3",
+            (3, 1):"TLSv1.0"
+            }.items():
+        for cipher_id, cipher_name in {
+                CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5:"DES-CBC3-MD5"
+                }.items():
+            # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
+            conversation = Connect(host, port, version=(0, 2))
+            node = conversation
+            ciphers = [CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_RC4_128_WITH_MD5,
+                       CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5,
+                       CipherSuite.SSL_CK_RC2_128_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5,
+                       CipherSuite.SSL_CK_IDEA_128_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_DES_64_CBC_WITH_MD5]
+
+            node = node.add_child(ClientHelloGenerator(ciphers,
+                                                       version=prot_vers,
+                                                       ssl2=True))
+            # we can get a ServerHello with no ciphers:
+            node = node.add_child(ExpectServerHello2())
+            # or we can get an error stright away, and connection closure
+            node.next_sibling = ExpectSSL2Alert(SSL2ErrorDescription.no_cipher)
+            node.next_sibling.add_child(ExpectClose())
+            alternative = node.next_sibling
+            # or the server may close the connection right away (likely in
+            # case SSLv2 is completely disabled)
+            alternative.next_sibling = ExpectClose()
+            alternative = alternative.next_sibling
+            # or finally, we can get a TLS Alert message
+            alternative.next_sibling = ExpectAlert()
+            alternative.next_sibling.add_child(ExpectClose())
+            # in case we got ServerHello, try to force one of the ciphers
+            node = node.add_child(ClientMasterKeyGenerator(cipher=cipher_id))
+            # it should result in error
+            node = node.add_child(ExpectSSL2Alert())
+            # or connection close
+            node.next_sibling = ExpectClose()
+            # in case of error, we expect the server to close connection
+            node = node.add_child(ExpectClose())
+
+            conversations["Connect with {1} {0}"
+                          .format(cipher_name, proto_name)] = conversation
+
+    good = 0
+    bad = 0
+
+    for conversation_name, conversation in conversations.items():
+        print("{0} ...".format(conversation_name))
+
+        runner = Runner(conversation)
+
+        res = True
+        try:
+            runner.run()
+        except:
+            print("Error while processing")
+            print(traceback.format_exc())
+            print("")
+            res = False
+
+        if res:
+            good+=1
+            print("OK\n")
+        else:
+            bad+=1
+
+    print("Note: SSLv2 was officially deprecated (MUST NOT use) in 2011, see")
+    print("      RFC 6176.")
+    print("      If one or more of the tests fails because of error in form of")
+    print("")
+    print("      Unexpected message from peer: Handshake()")
+    print("")
+    print("      With any number inside parethensis, and the server is")
+    print("      configured to not support SSLv2, it means it most")
+    print("      likely is vulnerable to CVE-2015-3197.")
+    print("      In case it's a RC4 or 3DES cipher, you may verify that it")
+    print("      really supports it using:")
+    print("      test-sslv2-connection.py")
+    print("")
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-sslv2-force-cipher-non3des.py
+++ b/scripts/test-sslv2-force-cipher-non3des.py
@@ -1,0 +1,154 @@
+# Author: Hubert Kario, (c) 2015
+# Released under Gnu GPL v2.0, see LICENSE file for details
+"""Test forcing non-3DES SSLv2 ciphers"""
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+        ClientMasterKeyGenerator, Close
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, \
+        ExpectAlert, ExpectClose, ExpectApplicationData, ExpectServerHello2, \
+        ExpectVerify, ExpectSSL2Alert
+
+from tlslite.constants import CipherSuite, AlertLevel, \
+        ExtensionType, SSL2ErrorDescription
+
+def help_msg():
+    """Usage information"""
+    print("Usage: <script-name> [-h hostname] [-p port]")
+    print(" -h hostname   hostname to connect to, \"localhost\" by default")
+    print(" -p port       port to use for connection, \"4433\" by default")
+    print(" --help        this message")
+
+def main():
+    """
+    Test forcing of non-3DES ciphers in SSLv2
+
+    Test if SSLv2 server supporting just 3DES won't allow client to force
+    different cipher
+    """
+    conversations = {}
+    host = "localhost"
+    port = 4433
+
+    argv = sys.argv[1:]
+
+    opts, argv = getopt.getopt(argv, "h:p:", ["help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+    if argv:
+        help_msg()
+        raise ValueError("Unknown options: {0}".format(argv))
+
+    for prot_vers, proto_name in {
+            (0, 2):"SSLv2",
+            (3, 0):"SSLv3",
+            (3, 1):"TLSv1.0"
+            }.items():
+        for cipher_id, cipher_name in {
+                CipherSuite.SSL_CK_RC4_128_WITH_MD5:"RC4-MD5",
+                CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5:"EXP-RC4-MD5",
+                CipherSuite.SSL_CK_RC2_128_CBC_WITH_MD5:"RC2-CBC-MD5",
+                CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5:
+                    "EXP-RC2-CBC-MD5",
+                CipherSuite.SSL_CK_IDEA_128_CBC_WITH_MD5:"IDEA-CBC-MD5",
+                CipherSuite.SSL_CK_DES_64_CBC_WITH_MD5:"DES-CBC-MD5"
+                }.items():
+            # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
+            conversation = Connect(host, port, version=(0, 2))
+            node = conversation
+            ciphers = [CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_RC4_128_WITH_MD5,
+                       CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5,
+                       CipherSuite.SSL_CK_RC2_128_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5,
+                       CipherSuite.SSL_CK_IDEA_128_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_DES_64_CBC_WITH_MD5]
+
+            node = node.add_child(ClientHelloGenerator(ciphers,
+                                                       version=prot_vers,
+                                                       ssl2=True))
+            # we can get a ServerHello with no ciphers:
+            node = node.add_child(ExpectServerHello2())
+            # or we can get an error stright away, and connection closure
+            node.next_sibling = ExpectSSL2Alert(SSL2ErrorDescription.no_cipher)
+            node.next_sibling.add_child(ExpectClose())
+            alternative = node.next_sibling
+            # or the server may close the connection right away (likely in
+            # case SSLv2 is completely disabled)
+            alternative.next_sibling = ExpectClose()
+            alternative = alternative.next_sibling
+            # or finally, we can get a TLS Alert message
+            alternative.next_sibling = ExpectAlert()
+            alternative.next_sibling.add_child(ExpectClose())
+            # in case we got ServerHello, try to force one of the ciphers
+            node = node.add_child(ClientMasterKeyGenerator(cipher=cipher_id))
+            # it should result in error
+            node = node.add_child(ExpectSSL2Alert())
+            # or connection close
+            node.next_sibling = ExpectClose()
+            # in case of error, we expect the server to close connection
+            node = node.add_child(ExpectClose())
+
+            conversations["Connect with {1} {0}"
+                          .format(cipher_name, proto_name)] = conversation
+
+    good = 0
+    bad = 0
+
+    for conversation_name, conversation in conversations.items():
+        print("{0} ...".format(conversation_name))
+
+        runner = Runner(conversation)
+
+        res = True
+        try:
+            runner.run()
+        except:
+            print("Error while processing")
+            print(traceback.format_exc())
+            print("")
+            res = False
+
+        if res:
+            good+=1
+            print("OK\n")
+        else:
+            bad+=1
+
+    print("Note: SSLv2 was officially deprecated (MUST NOT use) in 2011, see")
+    print("      RFC 6176.")
+    print("      If one or more of the tests fails because of error in form of")
+    print("")
+    print("      Unexpected message from peer: Handshake()")
+    print("")
+    print("      With any number inside parethensis, and the server is")
+    print("      configured to not support SSLv2, it means it most")
+    print("      likely is vulnerable to CVE-2015-3197.")
+    print("      In case it's a RC4 or 3DES cipher, you may verify that it")
+    print("      really supports it using:")
+    print("      test-sslv2-connection.py")
+    print("")
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-sslv2-force-cipher.py
+++ b/scripts/test-sslv2-force-cipher.py
@@ -1,0 +1,146 @@
+# Author: Hubert Kario, (c) 2015
+# Released under Gnu GPL v2.0, see LICENSE file for details
+"""Test if server won't accept forcing SSLv2 ciphers"""
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ClientMasterKeyGenerator
+from tlsfuzzer.expect import ExpectAlert, ExpectClose, ExpectServerHello2, \
+        ExpectSSL2Alert
+
+from tlslite.constants import CipherSuite, AlertLevel, \
+        ExtensionType, SSL2ErrorDescription
+
+def help_msg():
+    """Print usage information"""
+    print("Usage: <script-name> [-h hostname] [-p port]")
+    print(" -h hostname   hostname to connect to, \"localhost\" by default")
+    print(" -p port       port to use for connection, \"4433\" by default")
+    print(" --help        this message")
+
+def main():
+    """Test if the server supports some of the SSLv2 ciphers"""
+    conversations = {}
+    host = "localhost"
+    port = 4433
+
+    argv = sys.argv[1:]
+
+    opts, argv = getopt.getopt(argv, "h:p:", ["help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+    if argv:
+        help_msg()
+        raise ValueError("Unknown options: {0}".format(argv))
+
+    for prot_vers, proto_name in {
+            (0, 2):"SSLv2",
+            (3, 0):"SSLv3",
+            (3, 1):"TLSv1.0"
+            }.items():
+        for cipher_id, cipher_name in {
+                CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5:"DES-CBC3-MD5",
+                CipherSuite.SSL_CK_RC4_128_WITH_MD5:"RC4-MD5",
+                CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5:"EXP-RC4-MD5",
+                CipherSuite.SSL_CK_RC2_128_CBC_WITH_MD5:"RC2-CBC-MD5",
+                CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5:
+                    "EXP-RC2-CBC-MD5",
+                CipherSuite.SSL_CK_IDEA_128_CBC_WITH_MD5:"IDEA-CBC-MD5",
+                CipherSuite.SSL_CK_DES_64_CBC_WITH_MD5:"DES-CBC-MD5"
+                }.items():
+            # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
+            conversation = Connect(host, port, version=(0, 2))
+            node = conversation
+            ciphers = [CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_RC4_128_WITH_MD5,
+                       CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5,
+                       CipherSuite.SSL_CK_RC2_128_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5,
+                       CipherSuite.SSL_CK_IDEA_128_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_DES_64_CBC_WITH_MD5]
+
+            node = node.add_child(ClientHelloGenerator(ciphers,
+                                                       version=prot_vers,
+                                                       ssl2=True))
+            # we can get a ServerHello with no ciphers:
+            node = node.add_child(ExpectServerHello2())
+            # or we can get an error stright away, and connection closure
+            node.next_sibling = ExpectSSL2Alert(SSL2ErrorDescription.no_cipher)
+            node.next_sibling.add_child(ExpectClose())
+            alternative = node.next_sibling
+            # or the server may close the connection right away (likely in
+            # case SSLv2 is completely disabled)
+            alternative.next_sibling = ExpectClose()
+            alternative = alternative.next_sibling
+            # or finally, we can get a TLS Alert message
+            alternative.next_sibling = ExpectAlert()
+            alternative.next_sibling.add_child(ExpectClose())
+            # in case we got ServerHello, try to force one of the ciphers
+            node = node.add_child(ClientMasterKeyGenerator(cipher=cipher_id))
+            # it should result in error
+            node = node.add_child(ExpectSSL2Alert())
+            # or connection close
+            node.next_sibling = ExpectClose()
+            # in case of error, we expect the server to close connection
+            node = node.add_child(ExpectClose())
+
+            conversations["Connect with {1} {0}"
+                          .format(cipher_name, proto_name)] = conversation
+
+    good = 0
+    bad = 0
+
+    for conversation_name, conversation in conversations.items():
+        print("{0} ...".format(conversation_name))
+
+        runner = Runner(conversation)
+
+        res = True
+        try:
+            runner.run()
+        except:
+            print("Error while processing")
+            print(traceback.format_exc())
+            print("")
+            res = False
+
+        if res:
+            good+=1
+            print("OK\n")
+        else:
+            bad+=1
+
+    print("Note: SSLv2 was officially deprecated (MUST NOT use) in 2011, see")
+    print("      RFC 6176.")
+    print("      If one or more of the tests fails because of error in form of")
+    print("")
+    print("      Unexpected message from peer: Handshake()")
+    print("")
+    print("      With any number inside parethensis, and the server is")
+    print("      configured to not support SSLv2, it means it most")
+    print("      likely is vulnerable to CVE-2015-3197.")
+    print("      In case it's a RC4 or 3DES cipher, you may verify that it")
+    print("      really supports it using:")
+    print("      test-sslv2-connection.py")
+    print("")
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-sslv2-force-export-cipher.py
+++ b/scripts/test-sslv2-force-export-cipher.py
@@ -1,0 +1,145 @@
+# Author: Hubert Kario, (c) 2015
+# Released under Gnu GPL v2.0, see LICENSE file for details
+"""Test forcing of export ciphers in SSLv2"""
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+        ClientMasterKeyGenerator, Close
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, \
+        ExpectAlert, ExpectClose, ExpectApplicationData, ExpectServerHello2, \
+        ExpectVerify, ExpectSSL2Alert
+
+from tlslite.constants import CipherSuite, AlertLevel, \
+        ExtensionType, SSL2ErrorDescription
+
+def help_msg():
+    """Usage information"""
+    print("Usage: <script-name> [-h hostname] [-p port]")
+    print(" -h hostname   hostname to connect to, \"localhost\" by default")
+    print(" -p port       port to use for connection, \"4433\" by default")
+    print(" --help        this message")
+
+def main():
+    """Test if the server supports export grade SSLv2 ciphers"""
+    conversations = {}
+    host = "localhost"
+    port = 4433
+
+    argv = sys.argv[1:]
+
+    opts, argv = getopt.getopt(argv, "h:p:", ["help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+    if argv:
+        help_msg()
+        raise ValueError("Unknown options: {0}".format(argv))
+
+    for prot_vers, proto_name in {
+            (0, 2):"SSLv2",
+            (3, 0):"SSLv3",
+            (3, 1):"TLSv1.0"
+            }.items():
+        for cipher_id, cipher_name in {
+                CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5:"EXP-RC4-MD5",
+                CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5:
+                    "EXP-RC2-CBC-MD5"
+                }.items():
+            # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
+            conversation = Connect(host, port, version=(0, 2))
+            node = conversation
+            ciphers = [CipherSuite.SSL_CK_DES_192_EDE3_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_RC4_128_WITH_MD5,
+                       CipherSuite.SSL_CK_RC4_128_EXPORT40_WITH_MD5,
+                       CipherSuite.SSL_CK_RC2_128_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_RC2_128_CBC_EXPORT40_WITH_MD5,
+                       CipherSuite.SSL_CK_IDEA_128_CBC_WITH_MD5,
+                       CipherSuite.SSL_CK_DES_64_CBC_WITH_MD5]
+
+            node = node.add_child(ClientHelloGenerator(ciphers,
+                                                       version=prot_vers,
+                                                       ssl2=True))
+            # we can get a ServerHello with no ciphers:
+            node = node.add_child(ExpectServerHello2())
+            # or we can get an error stright away, and connection closure
+            node.next_sibling = ExpectSSL2Alert(SSL2ErrorDescription.no_cipher)
+            node.next_sibling.add_child(ExpectClose())
+            alternative = node.next_sibling
+            # or the server may close the connection right away (likely in
+            # case SSLv2 is completely disabled)
+            alternative.next_sibling = ExpectClose()
+            alternative = alternative.next_sibling
+            # or finally, we can get a TLS Alert message
+            alternative.next_sibling = ExpectAlert()
+            alternative.next_sibling.add_child(ExpectClose())
+            # in case we got ServerHello, try to force one of the ciphers
+            node = node.add_child(ClientMasterKeyGenerator(cipher=cipher_id))
+            # it should result in error
+            node = node.add_child(ExpectSSL2Alert())
+            # or connection close
+            node.next_sibling = ExpectClose()
+            # in case of error, we expect the server to close connection
+            node = node.add_child(ExpectClose())
+
+            conversations["Connect with {1} {0}"
+                          .format(cipher_name, proto_name)] = conversation
+
+    good = 0
+    bad = 0
+
+    for conversation_name, conversation in conversations.items():
+        print("{0} ...".format(conversation_name))
+
+        runner = Runner(conversation)
+
+        res = True
+        try:
+            runner.run()
+        except:
+            print("Error while processing")
+            print(traceback.format_exc())
+            print("")
+            res = False
+
+        if res:
+            good+=1
+            print("OK\n")
+        else:
+            bad+=1
+
+    print("Note: SSLv2 was officially deprecated (MUST NOT use) in 2011, see")
+    print("      RFC 6176.")
+    print("      If one or more of the tests fails because of error in form of")
+    print("")
+    print("      Unexpected message from peer: Handshake()")
+    print("")
+    print("      With any number inside parethensis, and the server is")
+    print("      configured to not support SSLv2, it means it most")
+    print("      likely is vulnerable to CVE-2015-3197 and CVE-2016-0800.")
+    print("      In case it's a RC4 or 3DES cipher, you may verify that it")
+    print("      really supports it using:")
+    print("      test-sslv2-connection.py")
+    print("")
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-sslv2hello-protocol.py
+++ b/scripts/test-sslv2hello-protocol.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 import traceback
 import sys
+import getopt
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
@@ -16,6 +17,13 @@ from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
         ExtensionType
 
+def help_msg():
+    """Usage information"""
+    print("Usage: <script-name> [-h hostname] [-p port]")
+    print(" -h hostname   hostname to connect to, \"localhost\" by default")
+    print(" -p port       port to use for connection, \"4433\" by default")
+    print(" --help        this message")
+
 def main():
     """
     Check SSLv2Hello support
@@ -24,9 +32,27 @@ def main():
     negotiating TLS connections
     """
     conversations = {}
+    host = "localhost"
+    port = 4433
+
+    argv = sys.argv[1:]
+    opts, argv = getopt.getopt(argv, "h:p:", ["help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+    if argv:
+        help_msg()
+        raise ValueError("Unknown options: {0}".format(argv))
 
     # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
-    conversation = Connect("localhost", 4433, version=(0, 2))
+    conversation = Connect(host, port, version=(0, 2))
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]

--- a/scripts/test-sslv2hello-protocol.py
+++ b/scripts/test-sslv2hello-protocol.py
@@ -1,0 +1,85 @@
+# Author: Hubert Kario, (c) 2015
+# Released under Gnu GPL v2.0, see LICENSE file for details
+"""Check for SSLv2 Client Hello support for negotiating TLS"""
+from __future__ import print_function
+import traceback
+import sys
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+        ExpectAlert, ExpectClose, ExpectApplicationData
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+        ExtensionType
+
+def main():
+    """
+    Check SSLv2Hello support
+
+    Test if the server supports SSLv2-style Client Hello messages for
+    negotiating TLS connections
+    """
+    conversations = {}
+
+    # instruct RecordLayer to use SSLv2 record layer protocol (0, 2)
+    conversation = Connect("localhost", 4433, version=(0, 2))
+    node = conversation
+    ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    node = node.add_child(ClientHelloGenerator(ciphers,
+                                               ssl2=True))
+    ext={ExtensionType.renegotiation_info:None}
+    node = node.add_child(ExpectServerHello(extensions=ext))
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectServerHelloDone())
+    node = node.add_child(ClientKeyExchangeGenerator())
+    node = node.add_child(ChangeCipherSpecGenerator())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\n\n")))
+    node = node.add_child(ExpectApplicationData())
+    node = node.add_child(AlertGenerator(AlertLevel.warning,
+                                         AlertDescription.close_notify))
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+
+    conversations["SSLv2 Client Hello"] = conversation
+
+    good = 0
+    bad = 0
+
+    for conversation_name, conversation in conversations.items():
+        print("{0} ...".format(conversation_name))
+
+        runner = Runner(conversation)
+
+        res = True
+        try:
+            runner.run()
+        except:
+            print("Error while processing")
+            print(traceback.format_exc())
+            print("")
+            res = False
+
+        if res:
+            good+=1
+            print("OK\n")
+        else:
+            bad+=1
+
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-sslv2hello-protocol.py
+++ b/scripts/test-sslv2hello-protocol.py
@@ -47,6 +47,10 @@ def main():
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
     node = node.add_child(ExpectAlert())
+    node.child = ExpectClose()
+    # if we're doing TLSv1.0 the server should be doing 1/n-1 splitting
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling
     node.next_sibling = ExpectClose()
 
     conversations["SSLv2 Client Hello"] = conversation

--- a/tests/test_tlsfuzzer_messages.py
+++ b/tests/test_tlsfuzzer_messages.py
@@ -72,6 +72,20 @@ class TestConnect(unittest.TestCase):
         instance.connect.assert_called_once_with((1, 2))
         self.assertIs(state.msg_sock.sock, instance)
 
+    @mock.patch('socket.socket')
+    def test_process_with_SSLv2(self, mock_sock):
+        state = ConnectionState()
+        connect = Connect(1, 2, (0, 2))
+
+        connect.process(state)
+
+        self.assertEqual(state.msg_sock.version, (0, 2))
+
+        mock_sock.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM)
+        instance = mock_sock.return_value
+        instance.connect.assert_called_once_with((1, 2))
+        self.assertIs(state.msg_sock.sock, instance)
+
 class TestRawMessageGenerator(unittest.TestCase):
     def test___init__(self):
         message_gen = RawMessageGenerator(12, bytearray(b'\xff\x02'))

--- a/tests/test_tlsfuzzer_messages.py
+++ b/tests/test_tlsfuzzer_messages.py
@@ -20,7 +20,7 @@ from tlsfuzzer.messages import ClientHelloGenerator, ClientKeyExchangeGenerator,
         RawMessageGenerator, split_message, PopMessageFromList, \
         FlushMessageList, fuzz_mac, fuzz_padding, ApplicationDataGenerator, \
         CertificateGenerator, CertificateVerifyGenerator, CertificateRequest, \
-        ResetRenegotiationInfo, fuzz_plaintext
+        ResetRenegotiationInfo, fuzz_plaintext, Connect
 from tlsfuzzer.runner import ConnectionState
 import tlslite.messages as messages
 import tlslite.messagesocket as messagesocket
@@ -31,6 +31,7 @@ import tlslite.defragmenter as defragmenter
 from tlslite.utils.codec import Parser
 from tests.mocksock import MockSocket
 from tlslite.utils.keyfactory import generateRSAKey
+import socket
 
 
 class TestClose(unittest.TestCase):
@@ -47,6 +48,29 @@ class TestClose(unittest.TestCase):
         close.process(state)
 
         state.msg_sock.sock.close.called_once_with()
+
+class TestConnect(unittest.TestCase):
+    def test___init__(self):
+        connect = Connect(1, 2)
+
+        self.assertIsNotNone(connect)
+        self.assertEqual(connect.hostname, 1)
+        self.assertEqual(connect.port, 2)
+        self.assertEqual(connect.version, (3, 0))
+
+    @mock.patch('socket.socket')
+    def test_process(self, mock_sock):
+        state = ConnectionState()
+        connect = Connect(1, 2)
+
+        connect.process(state)
+
+        self.assertEqual(state.msg_sock.version, (3, 0))
+
+        mock_sock.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM)
+        instance = mock_sock.return_value
+        instance.connect.assert_called_once_with((1, 2))
+        self.assertIs(state.msg_sock.sock, instance)
 
 class TestRawMessageGenerator(unittest.TestCase):
     def test___init__(self):

--- a/tests/test_tlsfuzzer_runner.py
+++ b/tests/test_tlsfuzzer_runner.py
@@ -272,3 +272,10 @@ class TestGuessResponse(unittest.TestCase):
 
         self.assertEqual("Message(content_type=250, first_byte=2, len=3)",
                          guess_response(content_type, data))
+
+    def test_guess_response_with_SSL2_hanshake(self):
+        content_type = constants.ContentType.handshake
+        data = bytearray([constants.SSL2HandshakeType.server_hello])
+
+        self.assertEqual("Handshake(server_hello)",
+                         guess_response(content_type, data, ssl2=True))

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -4,14 +4,17 @@
 """Parsing and processing of received TLS messages"""
 
 from tlslite.constants import ContentType, HandshakeType, CertificateType,\
-        HashAlgorithm, SignatureAlgorithm, ExtensionType
+        HashAlgorithm, SignatureAlgorithm, ExtensionType,\
+        SSL2HandshakeType
 from tlslite.messages import ServerHello, Certificate, ServerHelloDone,\
-        ChangeCipherSpec, Finished, Alert, CertificateRequest, \
-        ServerKeyExchange, ClientHello
+        ChangeCipherSpec, Finished, Alert, CertificateRequest, ServerHello2,\
+        ServerKeyExchange, ClientHello, ServerFinished
 from tlslite.utils.codec import Parser
 from tlslite.mathtls import calcFinished
 from .handshake_helpers import calc_pending_states
 from tlslite.keyexchange import KeyExchange, DHE_RSAKeyExchange
+from tlslite.x509 import X509
+from tlslite.x509certchain import X509CertChain
 from .tree import TreeNode
 
 class Expect(TreeNode):
@@ -78,6 +81,9 @@ class ExpectHandshake(Expect):
     def is_match(self, msg):
         """Check if message is a given type of handshake protocol message"""
         if not super(ExpectHandshake, self).is_match(msg):
+            return False
+
+        if not msg.write():  # if message is empty
             return False
 
         hs_type = Parser(msg.write()).get(1)
@@ -169,6 +175,55 @@ class ExpectServerHello(ExpectHandshake):
             if srv_hello.extensions is not None:
                 for ext_id in (ext.extType for ext in srv_hello.extensions):
                     assert ext_id in self.extensions
+
+class ExpectServerHello2(ExpectHandshake):
+    """Processing of SSLv2 Handshake Protocol SERVER-HELLO message"""
+
+    def __init__(self, version=None):
+        super(ExpectServerHello2, self).__init__(ContentType.handshake,
+                                                 SSL2HandshakeType.server_hello)
+        self.version = version
+
+    def process(self, state, msg):
+        """
+        Process the message and update state accordingly
+
+        @type state: ConnectionState
+        @param state: overall state of TLS connection
+
+        @type msg: Message
+        @param msg: TLS Message read from socket
+        """
+        # the value is faked for SSLv2 protocol, but let's just check sanity
+        assert msg.contentType == ContentType.handshake
+
+        parser = Parser(msg.write())
+        hs_type = parser.get(1)
+        assert hs_type == SSL2HandshakeType.server_hello
+
+        server_hello = ServerHello2().parse(parser)
+
+        state.handshake_messages.append(server_hello)
+        state.handshake_hashes.update(msg.write())
+
+        if self.version is not None:
+            assert self.version == server_hello.server_version
+
+        if server_hello.session_id_hit:
+            state.resuming = True
+        state.session_id = server_hello.session_id
+        state.server_random = server_hello.session_id
+        state.version = server_hello.server_version
+        state.msg_sock.version = server_hello.server_version
+
+        # fake a certificate message so finding the server public key works
+        x509 = X509()
+        x509.parseBinary(server_hello.certificate)
+        cert_chain = X509CertChain([x509])
+        certificate = Certificate(CertificateType.x509)
+        certificate.create(cert_chain)
+        state.handshake_messages.append(certificate)
+        # fake message so don't update handshake hashes
 
 class ExpectCertificate(ExpectHandshake):
 
@@ -337,13 +392,33 @@ class ExpectChangeCipherSpec(Expect):
 
         state.msg_sock.changeReadState()
 
+class ExpectVerify(ExpectHandshake):
+    """Processing of SSLv2 SERVER-VERIFY message"""
+
+    def __init__(self):
+        super(ExpectVerify, self).__init__(ContentType.handshake,
+                                           SSL2HandshakeType.server_verify)
+
+    def process(self, state, msg):
+        """Check if the VERIFY message has expected value"""
+        assert msg.contentType == ContentType.handshake
+        parser = Parser(msg.write())
+
+        msg_type = parser.get(1)
+        assert msg_type == SSL2HandshakeType.server_verify
+
 class ExpectFinished(ExpectHandshake):
 
     """Processing TLS handshake protocol Finished message"""
 
     def __init__(self, version=None):
-        super(ExpectFinished, self).__init__(ContentType.handshake,
-                                             HandshakeType.finished)
+        if version in ((0, 2), (2, 0)):
+            super(ExpectFinished, self).__init__(ContentType.handshake,
+                                                 SSL2HandshakeType.
+                                                 server_finished)
+        else:
+            super(ExpectFinished, self).__init__(ContentType.handshake,
+                                                 HandshakeType.finished)
         self.version = version
 
     def process(self, state, msg):
@@ -354,24 +429,34 @@ class ExpectFinished(ExpectHandshake):
         assert msg.contentType == ContentType.handshake
         parser = Parser(msg.write())
         hs_type = parser.get(1)
-        assert hs_type == HandshakeType.finished
+        assert hs_type == self.handshake_type
         if self.version is None:
             self.version = state.version
 
-        finished = Finished(self.version)
+        if self.version in ((0, 2), (2, 0)):
+            finished = ServerFinished()
+        else:
+            finished = Finished(self.version)
+
         finished.parse(parser)
 
-        verify_expected = calcFinished(state.version,
-                                       state.master_secret,
-                                       state.cipher,
-                                       state.handshake_hashes,
-                                       not state.client)
+        if self.version in ((0, 2), (2, 0)):
+            state.session_id = finished.verify_data
+        else:
+            verify_expected = calcFinished(state.version,
+                                           state.master_secret,
+                                           state.cipher,
+                                           state.handshake_hashes,
+                                           not state.client)
 
-        assert finished.verify_data == verify_expected
+            assert finished.verify_data == verify_expected
 
         state.handshake_messages.append(finished)
         state.server_verify_data = finished.verify_data
         state.handshake_hashes.update(msg.write())
+
+        if self.version in ((0, 2), (2, 0)):
+            state.msg_sock.handshake_finished = True
 
 class ExpectAlert(Expect):
 
@@ -401,6 +486,25 @@ class ExpectAlert(Expect):
                                         alert.description, self.description)
         if problem_desc:
             raise AssertionError(problem_desc)
+
+class ExpectSSL2Alert(ExpectHandshake):
+    """Processing of SSLv2 Handshake protocol alert messages"""
+
+    def __init__(self, error=None):
+        super(ExpectSSL2Alert, self).__init__(ContentType.handshake,
+                                              SSL2HandshakeType.error)
+        self.error = error
+
+    def process(self, state, msg):
+        """Analyse the error message"""
+        assert msg.contentType == ContentType.handshake
+
+        parser = Parser(msg.write())
+        hs_type = parser.get(1)
+        assert hs_type == SSL2HandshakeType.error
+
+        if self.error is not None:
+            assert self.error == parser.get(2)
 
 class ExpectApplicationData(Expect):
 

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -5,7 +5,8 @@
 
 from tlslite.messages import ClientHello, ClientKeyExchange, ChangeCipherSpec,\
         Finished, Alert, ApplicationData, Message, Certificate, \
-        CertificateVerify, CertificateRequest
+        CertificateVerify, CertificateRequest, ClientMasterKey, \
+        ClientFinished
 from tlslite.constants import AlertLevel, AlertDescription, ContentType, \
         ExtensionType, CertificateType, ClientCertificateType, HashAlgorithm, \
         SignatureAlgorithm, CipherSuite
@@ -16,6 +17,7 @@ from tlslite.mathtls import calcMasterSecret, calcFinished, \
         calcExtendedMasterSecret
 from tlslite.handshakehashes import HandshakeHashes
 from tlslite.utils.codec import Writer
+from tlslite.utils.cryptomath import getRandomBytes
 from tlslite.keyexchange import KeyExchange
 from .handshake_helpers import calc_pending_states
 from .tree import TreeNode
@@ -340,6 +342,61 @@ class ClientKeyExchangeGenerator(HandshakeProtocolMessageGenerator):
 
         return cke
 
+class ClientMasterKeyGenerator(HandshakeProtocolMessageGenerator):
+    """Generator for SSLv2 Handshake Protocol CLIENT-MASTER-KEY message"""
+
+    def __init__(self, cipher=None, master_key=None):
+        super(ClientMasterKeyGenerator, self).__init__()
+        self.cipher = cipher
+        self.master_key = master_key
+
+    def generate(self, state):
+        """Generate a new CLIENT-MASTER-KEY message"""
+        if self.cipher is None:
+            raise NotImplementedError("No cipher autonegotiation")
+        if self.master_key is None:
+            if state.master_secret == bytearray(0):
+                if self.cipher in CipherSuite.ssl2_128Key:
+                    key_size = 16
+                elif self.cipher in CipherSuite.ssl2_192Key:
+                    key_size = 24
+                elif self.cipher in CipherSuite.ssl2_64Key:
+                    key_size = 8
+                else:
+                    raise AssertionError("unknown cipher but no master_secret")
+                self.master_key = getRandomBytes(key_size)
+            else:
+                self.master_key = state.master_secret
+
+        cipher = self.cipher
+        if (cipher not in CipherSuite.ssl2rc4 and
+                cipher not in CipherSuite.ssl2_3des):
+            # tlslite-ng doesn't implement anything else, so we need to
+            # workaround calculation of pending states failure for test
+            # cases which don't really encrypt data
+            cipher = CipherSuite.SSL_CK_RC4_128_WITH_MD5
+
+        key_arg = state.msg_sock.calcSSL2PendingStates(cipher,
+                                                       self.master_key,
+                                                       state.client_random,
+                                                       state.server_random,
+                                                       None)
+
+        if self.cipher in CipherSuite.ssl2export:
+            clear_key = self.master_key[:-5]
+            secret_key = self.master_key[-5:]
+        else:
+            clear_key = bytearray(0)
+            secret_key = self.master_key
+
+        pub_key = state.get_server_public_key()
+        encrypted_master_key = pub_key.encrypt(secret_key)
+
+        cmk = ClientMasterKey()
+        cmk.create(self.cipher, clear_key, encrypted_master_key, key_arg)
+        self.msg = cmk
+        return cmk
+
 class CertificateGenerator(HandshakeProtocolMessageGenerator):
     """Generator for TLS handshake protocol Certificate message"""
 
@@ -452,15 +509,23 @@ class FinishedGenerator(HandshakeProtocolMessageGenerator):
         """Create a Finished message"""
         if self.protocol is None:
             self.protocol = status.version
-        finished = Finished(self.protocol)
 
-        verify_data = calcFinished(status.version,
-                                   status.master_secret,
-                                   status.cipher,
-                                   status.handshake_hashes,
-                                   status.client)
+        if self.protocol in ((0, 2), (2, 0)):
+            finished = ClientFinished()
+            verify_data = status.session_id
 
-        status.client_verify_data = verify_data
+            # in SSLv2 we're using it as a CCS-of-sorts too
+            status.msg_sock.changeWriteState()
+            status.msg_sock.changeReadState()
+        else:
+            finished = Finished(self.protocol)
+            verify_data = calcFinished(status.version,
+                                       status.master_secret,
+                                       status.cipher,
+                                       status.handshake_hashes,
+                                       status.client)
+
+            status.client_verify_data = verify_data
 
         finished.create(verify_data)
 

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -86,14 +86,12 @@ class Connect(Command):
 
     """Object used to connect to a TCP server"""
 
-    def __init__(self, hostname, port):
+    def __init__(self, hostname, port, version=(3, 0)):
         """Provide minimal settings needed to connect to other peer"""
         super(Connect, self).__init__()
         self.hostname = hostname
         self.port = port
-        # note that this is just the default record layer message,
-        # changed to version from server hello as soon as it is received
-        self.version = (3, 0)
+        self.version = version
 
     def process(self, state):
         """Connect to a server"""
@@ -237,7 +235,7 @@ class ClientHelloGenerator(HandshakeProtocolMessageGenerator):
     """Generator for TLS handshake protocol Client Hello messages"""
 
     def __init__(self, ciphers=None, extensions=None, version=None,
-                 session_id=None, random=None, compression=None):
+                 session_id=None, random=None, compression=None, ssl2=False):
         super(ClientHelloGenerator, self).__init__()
         if ciphers is None:
             ciphers = []
@@ -251,6 +249,7 @@ class ClientHelloGenerator(HandshakeProtocolMessageGenerator):
         self.session_id = session_id
         self.random = random
         self.compression = compression
+        self.ssl2 = ssl2
 
     def _generate_extensions(self, state):
         """Convert extension generators to extension objects"""
@@ -287,11 +286,11 @@ class ClientHelloGenerator(HandshakeProtocolMessageGenerator):
         if self.extensions is not None:
             extensions = self._generate_extensions(state)
 
-        clnt_hello = ClientHello().create(self.version,
-                                          state.client_random,
-                                          self.session_id,
-                                          self.ciphers,
-                                          extensions=extensions)
+        clnt_hello = ClientHello(self.ssl2).create(self.version,
+                                                   state.client_random,
+                                                   self.session_id,
+                                                   self.ciphers,
+                                                   extensions=extensions)
         clnt_hello.compression_methods = self.compression
         state.client_version = self.version
 

--- a/tlsfuzzer/runner.py
+++ b/tlsfuzzer/runner.py
@@ -5,11 +5,11 @@
 from __future__ import print_function
 
 import socket
-from tlslite.messages import Message, Certificate
+from tlslite.messages import Message, Certificate, RecordHeader2
 from tlslite.handshakehashes import HandshakeHashes
 from tlslite.errors import TLSAbruptCloseError
 from tlslite.constants import ContentType, HandshakeType, AlertLevel, \
-        AlertDescription
+        AlertDescription, SSL2HandshakeType
 from .expect import ExpectClose
 
 class ConnectionState(object):
@@ -89,7 +89,7 @@ class ConnectionState(object):
                 return msg
         return None
 
-def guess_response(content_type, data):
+def guess_response(content_type, data, ssl2=False):
     """Guess which kind of message is in the record layer payload"""
     if content_type == ContentType.change_cipher_spec:
         if len(data) != 1:
@@ -104,7 +104,10 @@ def guess_response(content_type, data):
     elif content_type == ContentType.handshake:
         if not data:
             return "Handshake(invalid size)"
-        return "Handshake({0})".format(HandshakeType.toStr(data[0]))
+        if ssl2:
+            return "Handshake({0})".format(SSL2HandshakeType.toStr(data[0]))
+        else:
+            return "Handshake({0})".format(HandshakeType.toStr(data[0]))
     elif content_type == ContentType.application_data:
         return "ApplicationData(len={0})".format(len(data))
     else:
@@ -156,8 +159,11 @@ class Runner(object):
                         # since we're aborting, the user can't clean up
                         self.state.msg_sock.sock.close()
                         raise AssertionError("Unexpected message from peer: " +
-                                             guess_response(msg.contentType,
-                                                            msg.write()))
+                                             guess_response(\
+                                                 msg.contentType,
+                                                 msg.write(),
+                                                 isinstance(header,
+                                                            RecordHeader2)))
 
                     node.process(self.state, msg)
 


### PR DESCRIPTION
Few new tests:
 * check if initiation of TLS connection is possible with SSLv2 style hello (a.k.a. SSL2Hello Protocol)
 * checking sanity of RC4 and 3DES ciphers in SSLv2 servers
 * test for checking that SSLv2 ciphers are really disabled

Depends on tomato42/tlslite-ng#92