### PR TITLE
unsupported curve fallback

### DIFF
--- a/scripts/test-unsupported-cuve-fallback.py
+++ b/scripts/test-unsupported-cuve-fallback.py
@@ -1,0 +1,89 @@
+# Author: Hubert Kario, (c) 2016
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+"""Minimal test for verifying ecdhe curve fallback"""
+
+from __future__ import print_function
+import traceback
+import sys
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+        ExpectApplicationData
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+        ExtensionType, GroupName
+from tlslite.extensions import SupportedGroupsExtension
+
+def main():
+    """Test if server supports unsupported curve fallback"""
+    conversations = {}
+
+    conversation = Connect("localhost", 4433)
+    node = conversation
+    ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+               CipherSuite.TLS_DHE_RSA_WITH_AES_256_GCM_SHA384]
+    ext = {ExtensionType.renegotiation_info:None,
+           ExtensionType.supported_groups:SupportedGroupsExtension()
+                .create([GroupName.secp192r1])}
+    node = node.add_child(ClientHelloGenerator(ciphers,
+                                               extensions=ext))
+    node = node.add_child(ExpectServerHello(cipher=CipherSuite.
+                                            TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+                                            , extensions={ExtensionType.
+                                                     renegotiation_info:None}))
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectServerKeyExchange())
+    node = node.add_child(ExpectServerHelloDone())
+    node = node.add_child(ClientKeyExchangeGenerator())
+    node = node.add_child(ChangeCipherSpecGenerator())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\n\n")))
+    node = node.add_child(ExpectApplicationData())
+    node = node.add_child(AlertGenerator(AlertLevel.warning,
+                                         AlertDescription.close_notify))
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+
+    conversations["check for unsupported curve fallback"] = conversation
+
+    good = 0
+    bad = 0
+
+    for conversation_name, conversation in conversations.items():
+        print("{0} ...".format(conversation_name))
+
+        runner = Runner(conversation)
+
+        res = True
+        try:
+            runner.run()
+        except:
+            print("Error while processing")
+            print(traceback.format_exc())
+            print("")
+            res = False
+
+        if res:
+            good+=1
+            print("OK\n")
+        else:
+            bad+=1
+
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -175,6 +175,24 @@ class TestExpectServerHello(unittest.TestCase):
         with self.assertRaises(AssertionError):
             exp.process(state, msg)
 
+    def test_process_with_incorrect_cipher(self):
+        exp = ExpectServerHello(cipher=5)
+
+        state = ConnectionState()
+        state.msg_sock = mock.MagicMock()
+
+        ext = RenegotiationInfoExtension().create()
+
+        msg = ServerHello().create(version=(3, 3),
+                                   random=bytearray(32),
+                                   session_id=bytearray(0),
+                                   cipher_suite=4)
+
+        self.assertTrue(exp.is_match(msg))
+
+        with self.assertRaises(AssertionError):
+            exp.process(state, msg)
+
     def test_process_with_unexpected_extensions(self):
         exp = ExpectServerHello(extensions={ExtensionType.renegotiation_info:
                                            None})

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -99,7 +99,8 @@ class ExpectServerHello(ExpectHandshake):
 
     """Parsing TLS Handshake protocol Server Hello messages"""
 
-    def __init__(self, extensions=None, version=None, resume=False):
+    def __init__(self, extensions=None, version=None, resume=False,
+                 cipher=None):
         """
         Initialize the object
 
@@ -110,6 +111,7 @@ class ExpectServerHello(ExpectHandshake):
         """
         super(ExpectServerHello, self).__init__(ContentType.handshake,
                                                 HandshakeType.server_hello)
+        self.cipher = cipher
         self.extensions = extensions
         self.version = version
         self.resume = resume
@@ -148,6 +150,9 @@ class ExpectServerHello(ExpectHandshake):
 
         if self.version is not None:
             assert self.version == srv_hello.server_version
+
+        if self.cipher is not None:
+            assert self.cipher == srv_hello.cipher_suite
 
         state.cipher = srv_hello.cipher_suite
         state.version = srv_hello.server_version


### PR DESCRIPTION
verify that the server will not negotiate ECDHE cipher
if it doesn't support the same curves as the client