### PR TITLE
specifying sigalgs for CertifiateRequest

### DIFF
--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -933,3 +933,36 @@ class TestExpectCertificateRequest(unittest.TestCase):
                       msg.write())
 
         exp.process(state, msg)
+
+    def test_sig_algs(self):
+        sig_algs = [(HashAlgorithm.sha1, SignatureAlgorithm.rsa),
+                    (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
+                    (HashAlgorithm.sha384, SignatureAlgorithm.rsa)]
+        exp = ExpectCertificateRequest(sig_algs=sig_algs)
+
+        state = ConnectionState()
+        msg = CertificateRequest((3, 3))
+        msg.create([ClientCertificateType.rsa_sign,
+                    ClientCertificateType.rsa_fixed_dh],
+                   [],
+                   sig_algs)
+        msg = Message(ContentType.handshake, msg.write())
+
+        exp.process(state, msg)
+
+    def test_sig_algs_mismatched(self):
+        sig_algs = [(HashAlgorithm.sha1, SignatureAlgorithm.rsa),
+                    (HashAlgorithm.sha256, SignatureAlgorithm.rsa),
+                    (HashAlgorithm.sha384, SignatureAlgorithm.rsa)]
+        exp = ExpectCertificateRequest(sig_algs=sig_algs[0:0])
+
+        state = ConnectionState()
+        msg = CertificateRequest((3, 3))
+        msg.create([ClientCertificateType.rsa_sign,
+                    ClientCertificateType.rsa_fixed_dh],
+                   [],
+                   sig_algs)
+        msg = Message(ContentType.handshake, msg.write())
+
+        with self.assertRaises(AssertionError):
+            exp.process(state, msg)

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -358,13 +358,13 @@ class ExpectServerKeyExchange(ExpectHandshake):
 class ExpectCertificateRequest(ExpectHandshake):
     """Processing TLS Handshake protocol Certificate Request message"""
 
-    def __init__(self):
+    def __init__(self, sig_algs=None):
         msg_type = HandshakeType.certificate_request
         super(ExpectCertificateRequest, self).__init__(ContentType.handshake,
                                                        msg_type)
+        self.sig_algs = sig_algs
 
-    @staticmethod
-    def process(state, msg):
+    def process(self, state, msg):
         """
         Check received Certificate Request
 
@@ -378,6 +378,11 @@ class ExpectCertificateRequest(ExpectHandshake):
 
         cert_request = CertificateRequest(state.version)
         cert_request.parse(parser)
+        if self.sig_algs is not None and \
+                cert_request.supported_signature_algs != self.sig_algs:
+            raise AssertionError("Unexpected algorithms found: {0}"
+                                 .format(cert_request.supported_signature_algs)
+                                )
 
         state.handshake_messages.append(cert_request)
         state.handshake_hashes.update(msg.write())


### PR DESCRIPTION
allow for setting the expected list of advertised sigalgs
in CertificateRequest