### PR TITLE
Add host/port parameters for test-zero-length-data.py

### DIFF
--- a/scripts/test-zero-length-data.py
+++ b/scripts/test-zero-length-data.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 import traceback
 import sys
+import getopt
 
 from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
@@ -17,11 +18,38 @@ from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription
 
+
+def help_msg():
+    print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
+    print(" -h hostname    name of the host to run the test against")
+    print("                localhost by default")
+    print(" -p port        port number to use for connection, 4433 by default")
+    print(" --help         this message")
+
+
 def main():
     """check if app data records with zero payload are accepted by server"""
     conversations = {}
+    host = "localhost"
+    port = 4433
 
-    conversation = Connect("localhost", 4433)
+    argv = sys.argv[1:]
+    opts, argv = getopt.getopt(argv, "h:p:", ["help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+    if argv:
+        help_msg()
+        raise ValueError("Unknown options: {0}".format(argv))
+
+    conversation = Connect(host, port)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]


### PR DESCRIPTION
Some of the scripts in tlsfuzzer don't support passing the host/port via the command line.

I have copied the parameter parsing over from
test-sslv2hello-protocol.py

If you're fine with these changes I'll send more pull requests to do the same for all the remaining scripts that don't support it yet.