### PR TITLE
ignore files which are used when running with local tlslite/ecdsa lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ var/
 .installed.cfg
 *.egg
 
+# When running with embedded tlslite/ecdsa lib these should be hidden
+ecdsa
+tlslite
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.


### PR DESCRIPTION
When using tlsfuzzer as a submodule with a local tlslite (required for TLS1.3) as in `USAGE.md`, it results to an unclean tree:
```
	modified:   tlsfuzzer (untracked content)
```
This patch ignores the recommended directories, allowing a clean tree when tlsfuzzer is used as submodule.