### PR TITLE
add TLS1.3 conversation script to retention testing

### DIFF
--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -165,6 +165,7 @@
          {"name" : "test-SSLv3-padding.py",
           "comment" : "SSLv3 is disabled by default in tlslite-ng",
           "exp_pass" : false},
+         {"name" : "test-tls13-conversation.py"},
          {"name" : "test-tls13-pkcs-signature.py"},
          {"name" : "test-TLSv1_2-rejected-without-TLSv1_2.py"},
          {"name" : "test-truncating-of-client-hello.py"},

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -155,6 +155,7 @@
          {"name" : "test-SSLv3-padding.py",
           "comment" : "SSLv3 is disabled by default in tlslite-ng",
           "exp_pass" : false},
+         {"name" : "test-tls13-conversation.py"},
          {"name" : "test-tls13-pkcs-signature.py"},
          {"name" : "test-TLSv1_2-rejected-without-TLSv1_2.py"},
          {"name" : "test-truncating-of-client-hello.py"},


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

<!-- See CONTRIBUTING.md file for test environment setup -->

### Description
<!-- Describe your changes in detail below -->
the `test-tls13-conversation.py` was not part of the retention scripts add them there

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
all test scripts need to be run to ensure they continue working as tlsfuzzer develops

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
if you're unsure about any of those items, just ask -->

- [X] my code follows the style requirements
- [x] the changes are also reflected in documentation and code comments
- [x] I have read the **CONTRIBUTING** document
- [x] the added test cases cover the modified or added code—N/A
- [ ] all new and existing tests pass (see Travis CI results)
- [x] test script added to `tlslite-ng.json` and  `tlslite-ng-random-subset.json`