### PR TITLE
remove duplicated TestConnect class

### DIFF
--- a/tests/test_tlsfuzzer_messages.py
+++ b/tests/test_tlsfuzzer_messages.py
@@ -39,25 +39,6 @@ from tlslite.utils.cryptomath import numberToByteArray
 import socket
 import os
 
-class TestConnect(unittest.TestCase):
-    def test___init__(self):
-        node = Connect(None, None)
-        self.assertIsNotNone(node)
-
-    @mock.patch('socket.socket')
-    def test_process(self, raw_sock):
-        state = ConnectionState()
-        self.assertIsNone(state.msg_sock)
-
-        node = Connect('localhost', 4433)
-
-        node.process(state)
-
-        raw_sock.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM)
-        raw_sock.return_value.connect.assert_called_once_with(('localhost',
-                                                               4433))
-        self.assertIsNotNone(state.msg_sock)
-
 class TestClose(unittest.TestCase):
     def test___init__(self):
         close = Close()
@@ -209,7 +190,7 @@ class TestConnect(unittest.TestCase):
     @mock.patch('socket.socket')
     def test_process(self, mock_sock):
         state = ConnectionState()
-        connect = Connect(1, 2)
+        connect = Connect("localhost", 4433)
 
         connect.process(state)
 
@@ -217,7 +198,7 @@ class TestConnect(unittest.TestCase):
 
         mock_sock.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM)
         instance = mock_sock.return_value
-        instance.connect.assert_called_once_with((1, 2))
+        instance.connect.assert_called_once_with(("localhost", 4433))
         self.assertIs(state.msg_sock.sock.socket, instance)
 
     @mock.patch('socket.socket')


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

<!-- See CONTRIBUTING.md file for test environment setup -->

### Description
<!-- Describe your changes in detail below -->
integrate the more readable approach from the smaller class

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
only the last definition with duplicate name is used, adding code to the first instance of `TestConnection` would make the test code useless

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
if you're unsure about any of those items, just ask in comment to PR -->

- [x] my code follows the style requirements
- [x] the changes are also reflected in documentation and code comments
- [x] I have read the **CONTRIBUTING** document
- [x] the added test cases cover the modified or added code
- [x] all new and existing tests pass (see Travis CI results)
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [X] new and modified scripts were ran against popular TLS implementations:
  - N/A
- [X] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/233)
<!-- Reviewable:end -->
