### PR TITLE
Update the sanity conversation test to work with GnuTLS

### DIFF
--- a/scripts/test-tls13-conversation.py
+++ b/scripts/test-tls13-conversation.py
@@ -102,10 +102,16 @@ def main():
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ApplicationDataGenerator(
         bytearray(b"GET / HTTP/1.0\r\n\r\n")))
-    node = node.add_child(ExpectNewSessionTicket())
-    node = node.add_child(ExpectApplicationData())
-    node = node.add_child(AlertGenerator(AlertLevel.warning,
-                                         AlertDescription.close_notify))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                       AlertDescription.close_notify))
+
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["sanity"] = conversation

--- a/scripts/test-tls13-conversation.py
+++ b/scripts/test-tls13-conversation.py
@@ -85,7 +85,7 @@ def main():
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
     ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
-        .create([(3, 3), TLS_1_3_DRAFT])
+        .create([TLS_1_3_DRAFT, (3, 3)])
     ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,


### PR DESCRIPTION
### Description
The change is allowing to send zero or more New Session Ticket messages during the conversation. It also prefers the TLS 1.3 version in hello message (putting in the first place).

### Motivation and Context
This was needed for current GnuTLS, which is not (yet) sending New Session Ticket messages.

### Checklist

- [X] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [X] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [X] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [-] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [X] OpenSSL
  - [x] NSS
  - [X] GnuTLS
- [-] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/383)
<!-- Reviewable:end -->
