### PR TITLE
extend tests for SSLv3 padding, add negative test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tlslite-ng>=0.8.0-alpha7
+tlslite-ng>=0.8.0-alpha9

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -163,9 +163,6 @@
          {"name" : "test-sslv2-force-cipher.py"},
          {"name" : "test-sslv2-force-export-cipher.py"},
          {"name" : "test-sslv2hello-protocol.py"},
-         {"name" : "test-SSLv3-padding.py",
-          "comment" : "SSLv3 is disabled by default in tlslite-ng",
-          "exp_pass" : false},
          {"name" : "test-tls13-conversation.py"},
          {"name" : "test-tls13-empty-alert.py"},
          {"name" : "test-tls13-legacy-version.py"},
@@ -226,6 +223,19 @@
           "arguments" : ["-k", "tests/clientX509Key.pem",
                          "-c", "tests/clientX509Cert.pem"]
           }
+     ]
+    },
+    {"server_command": ["python", "-u", "{command}", "server",
+                 "-k", "tests/serverX509Key.pem",
+                 "-c", "tests/serverX509Cert.pem",
+                 "--ssl3",
+                 "localhost:4433"],
+     "server_hostname": "localhost",
+     "server_port": 4433,
+     "environment": {"PYTHONPATH": "."},
+     "comment" : "Tests of the SSLv3 implementation",
+     "tests" : [
+         {"name" : "test-SSLv3-padding.py"}
      ]
     }
 ]

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -153,9 +153,6 @@
          {"name" : "test-sslv2-force-cipher.py"},
          {"name" : "test-sslv2-force-export-cipher.py"},
          {"name" : "test-sslv2hello-protocol.py"},
-         {"name" : "test-SSLv3-padding.py",
-          "comment" : "SSLv3 is disabled by default in tlslite-ng",
-          "exp_pass" : false},
          {"name" : "test-tls13-conversation.py"},
          {"name" : "test-tls13-empty-alert.py"},
          {"name" : "test-tls13-legacy-version.py"},
@@ -216,6 +213,19 @@
           "arguments" : ["-k", "tests/clientX509Key.pem",
                          "-c", "tests/clientX509Cert.pem"]
           }
+     ]
+    },
+    {"server_command": ["python", "-u", "{command}", "server",
+                 "-k", "tests/serverX509Key.pem",
+                 "-c", "tests/serverX509Cert.pem",
+                 "--ssl3",
+                 "localhost:4433"],
+     "server_hostname": "localhost",
+     "server_port": 4433,
+     "environment": {"PYTHONPATH": "."},
+     "comment" : "Tests of the SSLv3 implementation",
+     "tests" : [
+         {"name" : "test-SSLv3-padding.py"}
      ]
     }
 ]


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
extend the SSLv3 test script for padding, added negative check

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
more detailed testing of the SSLv3 protocol

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [X] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [X] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [X] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [X] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

depends on https://github.com/tomato42/tlslite-ng/pull/271

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/403)
<!-- Reviewable:end -->
