### PR TITLE
scripts: advertise supported_versions in most-preferred order

### DIFF
--- a/scripts/test-tls13-pkcs-signature.py
+++ b/scripts/test-tls13-pkcs-signature.py
@@ -83,7 +83,7 @@ def main():
         key_shares.append(key_share_gen(group))
     ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
     ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
-        .create([(3, 3), TLS_1_3_DRAFT])
+        .create([TLS_1_3_DRAFT, (3, 3)])
     ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
         .create(groups)
     sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
@@ -120,7 +120,7 @@ def main():
             key_shares.append(key_share_gen(group))
         ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
         ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
-            .create([(3, 3), TLS_1_3_DRAFT])
+            .create([TLS_1_3_DRAFT, (3, 3)])
         ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
             .create(groups)
         sig_algs = [(getattr(HashAlgorithm, hash_alg), SignatureAlgorithm.rsa)]


### PR DESCRIPTION
Otherwise, if the server is configured with both TLS 1.3 and TLS 1.2,
the test-tls13-pkcs-signature fails because TLS 1.2 is negotiated.

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [x] GnuTLS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/406)
<!-- Reviewable:end -->
