### PR TITLE
expect server to transition to ap keys after server Finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You'll need:
 
  * Python 2.6 or later or Python 3.2 or later
  * [tlslite-ng](https://github.com/tomato42/tlslite-ng)
-   0.8.0-alpha8 or later (note that `tlslite` will *not* work and
+   0.8.0-alpha12 or later (note that `tlslite` will *not* work and
    they conflict with each other)
  * [ecdsa](https://github.com/warner/python-ecdsa)
    python module (dependency of tlslite-ng, should get installed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tlslite-ng>=0.8.0-alpha11
+tlslite-ng>=0.8.0-alpha12

--- a/scripts/test-tls13-zero-length-data.py
+++ b/scripts/test-tls13-zero-length-data.py
@@ -28,7 +28,7 @@ from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
 from tlsfuzzer.helpers import key_share_gen
 
 
-version = 1
+version = 2
 
 
 def help_msg():
@@ -300,6 +300,7 @@ def main():
     node = node.add_child(ApplicationDataGenerator(bytearray(0)))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.unexpected_message))
+    node.add_child(ExpectClose())
     conversations["zero-length app data during handshake"] = conversation
 
     # Send zero-length application data while handshaking with padding
@@ -333,6 +334,7 @@ def main():
     node = node.add_child(ApplicationDataGenerator(bytearray(0)))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.unexpected_message))
+    node.add_child(ExpectClose())
     conversations["zero-length app data with padding during handshake"] =\
         conversation
 
@@ -367,6 +369,7 @@ def main():
     node = node.add_child(ApplicationDataGenerator(bytearray(0)))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.unexpected_message))
+    node.add_child(ExpectClose())
     conversations["zero-len app data with large padding during handshake"] =\
         conversation
 
@@ -396,6 +399,7 @@ def main():
     node = node.add_child(ApplicationDataGenerator(bytearray(0)))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.unexpected_message))
+    node.add_child(ExpectClose())
     conversations["zero-length app data interleaved in handshake"] =\
         conversation
 
@@ -427,6 +431,7 @@ def main():
     node = node.add_child(ApplicationDataGenerator(bytearray(0)))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.unexpected_message))
+    node.add_child(ExpectClose())
     conversations["zero-len app data with padding interleaved in "
                   "handshake"] = conversation
 
@@ -458,6 +463,7 @@ def main():
     node = node.add_child(ApplicationDataGenerator(bytearray(0)))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.unexpected_message))
+    node.add_child(ExpectClose())
     conversations["zero-len app data with large padding interleaved in "
                   "handshake"] = conversation
 

--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -1542,6 +1542,7 @@ class TestExpectFinished(unittest.TestCase):
         state = ConnectionState()
         state.cipher = CipherSuite.TLS_AES_128_GCM_SHA256
         state.version = (3, 4)
+        state.key['handshake secret'] = bytearray(32)
         state.key['server handshake traffic secret'] = bytearray(32)
         state.msg_sock = mock.MagicMock()
         msg = Finished((3, 4), 32).create(

--- a/tests/test_tlsfuzzer_messages.py
+++ b/tests/test_tlsfuzzer_messages.py
@@ -1057,21 +1057,15 @@ class TestFinishedGenerator(unittest.TestCase):
             b'\xb3V\x8f\xc7[\xcdD\xc8\xa4\x86\xcf\xd3\xc9\x0c'))
 
         state.key['handshake secret'] = bytearray(32)
+        state.key['master secret'] = bytearray(32)
 
         fg.post_send(state)
 
-        state.msg_sock.calcTLS1_3PendingState.assert_called_once_with(
-            state.cipher,
-            state.key['client application traffic secret'],
-            state.key['server application traffic secret'],
-            None)
         state.msg_sock.changeWriteState.assert_called_once_with()
-        state.msg_sock.changeReadState.assert_called_once_with()
 
-        self.assertEqual(state.key['resumption master secret'], bytearray(
-            b'\xf8\xcfk\x1d\x9b\xd6\xe2V\x9f\x08\xa8\xae\xe4\xab'
-            b'\xee7\xc2>\x98\xf4w\x9f\x9e3\x14qq\xdf:\xf6\xa8z'
-            ))
+        self.assertEqual(state.key['resumption master secret'],
+            bytearray(b'\x89\xd8\x00l c$\x01\x0f\xd9j\x16\xa3\xbaV\xfesT\x8b'
+                      b'\xc6\xeb\x0f~\r\xbd\xb3R\xeb\xd5\x08\xa7\xbd'))
 
 
 class TestResetHandshakeHashes(unittest.TestCase):

--- a/tests/test_tlsfuzzer_messages.py
+++ b/tests/test_tlsfuzzer_messages.py
@@ -467,7 +467,6 @@ class TestClientHelloGenerator(unittest.TestCase):
                               extensions.PreSharedKeyExtension)
         ext = msg.extensions[1]
         self.assertEqual(len(ext.binders), 1)
-        print(repr(ext.binders[0]))
         self.assertEqual(
             ext.binders[0],
             bytearray(b"\x04!\xd0\xee\x0c\xe8\x13W\xa9\x85\xcc\xce\x07U\x87"


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
the TLS 1.3 draft states:
```
   Any records following a Finished message MUST be encrypted under the
   appropriate application traffic key as described in Section 7.2.
```

so expect alerts to malformed messages from client to be
sent using application data keys, not handshake keys

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
depends on https://github.com/tomato42/tlslite-ng/pull/273
fixes #405 

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [x] NSS
  - [x] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/407)
<!-- Reviewable:end -->
