### PR TITLE
restore CI support for python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,8 @@ before_install:
   - chmod +x ./cc-test-reporter
 
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2 'isort<4.3' 'inflect<0.3.1' 'coveralls<1.3.0' 'pyopenssl<18'; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install 'requests<2.11' 'coverage<4' 'coveralls<1'; else travis_retry pip install 'coverage' 'coveralls'; fi
+  - if [[ -e build-requirements-${TRAVIS_PYTHON_VERSION}.txt ]]; then travis_retry pip install -r build-requirements-${TRAVIS_PYTHON_VERSION}.txt; else travis_retry pip install -r build-requirements.txt; fi
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install -r build-requirements.txt
   - |
       if [[ $TRAVIS_PYTHON_VERSION == '2.6' || $TRAVIS_PYTHON_VERSION == '2.7' ]]; then
           travis_retry pip install --global-option=build_ext --global-option="-I/usr/include/x86_64-linux-gnu" m2crypto;

--- a/build-requirements-2.6.txt
+++ b/build-requirements-2.6.txt
@@ -1,0 +1,8 @@
+isort<4.3
+inflect<0.3.1
+pyopenssl<18
+unittest2
+coverage
+coveralls<1.3.0
+pylint
+diff_cover

--- a/build-requirements-3.2.txt
+++ b/build-requirements-3.2.txt
@@ -1,0 +1,5 @@
+requests<2.11
+coverage<4
+coveralls<1
+pylint
+diff_cover

--- a/build-requirements-3.2.txt
+++ b/build-requirements-3.2.txt
@@ -1,5 +1,5 @@
 requests<2.11
 coverage<4
 coveralls<1
-pylint
+pylint<2.0
 diff_cover

--- a/build-requirements-3.2.txt
+++ b/build-requirements-3.2.txt
@@ -1,3 +1,4 @@
+PyYAML<3.13
 requests<2.11
 coverage<4
 coveralls<1

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,2 +1,4 @@
+coverage
+coveralls
 pylint
 diff_cover


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
clean up build dependency package installation, restore python 3.2 compatibility

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
we want to support python 3.2 and later, to do that, we need to have test coverage from 3.2

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [X] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [X] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [X] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
  - n/a
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
  - n/a
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/425)
<!-- Reviewable:end -->
