### PR TITLE
Session resumption

### DIFF
--- a/scripts/test-tls13-session-resumption.py
+++ b/scripts/test-tls13-session-resumption.py
@@ -1,0 +1,272 @@
+# Author: Hubert Kario, (c) 2018
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+from itertools import chain, islice
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme, \
+        PskKeyExchangeMode
+from tlslite.extensions import ClientKeyShareExtension, \
+        SupportedVersionsExtension, SupportedGroupsExtension, \
+        SignatureAlgorithmsExtension, PskKeyExchangeModesExtension
+
+from tlsfuzzer.utils.lists import natural_sort_keys
+from tlsfuzzer.utils.ordered_dict import OrderedDict
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+        Close, ResetHandshakeHashes, ResetRenegotiationInfo
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectChangeCipherSpec, ExpectFinished, \
+        ExpectAlert, ExpectApplicationData, ExpectClose, \
+        ExpectEncryptedExtensions, ExpectCertificateVerify, \
+        ExpectNewSessionTicket, srv_ext_handler_supp_vers, \
+        gen_srv_ext_handler_psk, srv_ext_handler_key_share
+from tlsfuzzer.helpers import key_share_gen, psk_session_ext_gen, \
+        psk_ext_updater
+
+
+version = 1
+
+
+def help_msg():
+    print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
+    print(" -h hostname    name of the host to run the test against")
+    print("                localhost by default")
+    print(" -p port        port number to use for connection, 4433 by default")
+    print(" probe-name     if present, will run only the probes with given")
+    print("                names and not all of them, e.g \"sanity\"")
+    print(" -e probe-name  exclude the probe from the list of the ones run")
+    print("                may be specified multiple times")
+    print(" -n num         only run `num` random tests instead of a full set")
+    print("                (excluding \"sanity\" tests)")
+    print(" --help         this message")
+
+
+def main():
+    host = "localhost"
+    port = 4433
+    num_limit = None
+    run_exclude = set()
+
+    argv = sys.argv[1:]
+    opts, args = getopt.getopt(argv, "h:p:e:n:", ["help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '-e':
+            run_exclude.add(arg)
+        elif opt == '-n':
+            num_limit = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+
+    if args:
+        run_only = set(args)
+    else:
+        run_only = None
+
+    conversations = {}
+
+    # basic connection
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        .create(sig_algs)
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+        .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+    # ensure that the server sends at least one NST always
+    node = node.add_child(ExpectNewSessionTicket())
+
+    # but multiple ones are OK too
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(
+        AlertGenerator(AlertLevel.warning,
+                       AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert(AlertLevel.warning,
+                                      AlertDescription.close_notify))
+    node.next_sibling = ExpectClose()
+    node.add_child(ExpectClose())
+    conversations["sanity"] = conversation
+
+    # resume a session
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        .create(sig_algs)
+    ext[ExtensionType.psk_key_exchange_modes] = PskKeyExchangeModesExtension()\
+        .create([PskKeyExchangeMode.psk_dhe_ke, PskKeyExchangeMode.psk_ke])
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+    # ensure that the server sends at least one NST always
+    node = node.add_child(ExpectNewSessionTicket())
+
+    # but multiple ones are OK too
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(
+        AlertGenerator(AlertLevel.warning,
+                       AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert(AlertLevel.warning,
+                                      AlertDescription.close_notify))
+    # server can close connection without sending alert
+    close = ExpectClose()
+    node.next_sibling = close
+    node = node.add_child(close)
+    node = node.add_child(Close())
+    node = node.add_child(Connect(host, port))
+
+    # start the second handshake
+    node = node.add_child(ResetHandshakeHashes())
+    node = node.add_child(ResetRenegotiationInfo())
+    ext = OrderedDict(ext)
+    ext[ExtensionType.pre_shared_key] = psk_session_ext_gen()
+    mods = []
+    mods.append(psk_ext_updater())
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext,
+                                               modifiers=mods))
+    ext = {}
+    ext[ExtensionType.supported_versions] = srv_ext_handler_supp_vers
+    ext[ExtensionType.pre_shared_key] = gen_srv_ext_handler_psk()
+    ext[ExtensionType.key_share] = srv_ext_handler_key_share
+    node = node.add_child(ExpectServerHello(extensions=ext))
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+    # ensure that the server sends at least one NST always
+    node = node.add_child(ExpectNewSessionTicket())
+
+    # but multiple ones are OK too
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(
+        AlertGenerator(AlertLevel.warning,
+                       AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert(AlertLevel.warning,
+                                      AlertDescription.close_notify))
+    node.next_sibling = ExpectClose()
+    node.add_child(ExpectClose())
+    conversations["session resumption"] = conversation
+
+    # run the conversation
+    good = 0
+    bad = 0
+    failed = []
+    if not num_limit:
+        num_limit = len(conversations)
+
+    # make sure that sanity test is run first and last
+    # to verify that server was running and kept running throught
+    sanity_test = ('sanity', conversations['sanity'])
+    ordered_tests = chain([sanity_test],
+                          islice(filter(lambda x: x[0] != 'sanity',
+                                        conversations.items()), num_limit),
+                          [sanity_test])
+
+    for c_name, c_test in ordered_tests:
+        if run_only and c_name not in run_only or c_name in run_exclude:
+            continue
+        print("{0} ...".format(c_name))
+
+        runner = Runner(c_test)
+
+        res = True
+        try:
+            runner.run()
+        except Exception:
+            print("Error while processing")
+            print(traceback.format_exc())
+            res = False
+
+        if res:
+            good += 1
+            print("OK\n")
+        else:
+            bad += 1
+            failed.append(c_name)
+
+    print("Basic session resumption test with TLS 1.3 server\n")
+    print("version: {0}\n".format(version))
+
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+    failed_sorted = sorted(failed, key=natural_sort_keys)
+    print("  {0}".format('\n  '.join(repr(i) for i in failed_sorted)))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -1603,6 +1603,7 @@ class TestExpectNewSessionTicket(unittest.TestCase):
         exp.process(state, nst)
 
         self.assertIn(nst, state.session_tickets)
+        self.assertIsNotNone(state.session_tickets[0].time)
 
 
 class TestExpectVerify(unittest.TestCase):

--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -999,7 +999,8 @@ class TestExpectServerHelloWithHelloRetryRequest(unittest.TestCase):
         self.ch = ch
         state.handshake_messages.append(ch)
 
-        exts = [SrvSupportedVersionsExtension().create((3, 4))]
+        exts = [SrvSupportedVersionsExtension().create((3, 4)),
+                HRRKeyShareExtension().create(2)]
         hrr = ServerHello()
         hrr.create((3, 3), TLS_1_3_HRR, b'', 0x0004, extensions=exts)
         self.hrr = hrr
@@ -1016,10 +1017,8 @@ class TestExpectServerHelloWithHelloRetryRequest(unittest.TestCase):
     def test_with_wrong_hrr_random(self):
         self.hrr.random = bytearray([12]*32)
 
-        with self.assertRaises(ValueError) as e:
-            self.exp.process(self.state, self.sh)
-
-        self.assertIn("Two ServerHello", str(e.exception))
+        with self.assertRaises(SyntaxError):
+            self.exp.process(self.state, self.hrr)
 
     def test_with_wrong_cipher_suite(self):
         self.sh.cipher_suite = 5

--- a/tests/test_tlsfuzzer_messages.py
+++ b/tests/test_tlsfuzzer_messages.py
@@ -331,6 +331,29 @@ class TestClientHelloGenerator(unittest.TestCase):
         self.assertIsNotNone(chg)
         self.assertEqual(chg.ciphers, [])
 
+    def test___repr__(self):
+        chg = ClientHelloGenerator()
+        chg.compression = []
+
+        self.assertEqual("ClientHelloGenerator()", repr(chg))
+
+    def test___repr___with_values(self):
+        chg = ClientHelloGenerator(
+            [2, 3], ["ext"], (3, 3), bytearray(b'sess'), bytearray(b'random'),
+            [0xc0], True, ["mod"])
+
+        self.assertEqual(
+            "ClientHelloGenerator("
+            "ssl2=True, "
+            "version=(3, 3), "
+            "ciphers=[2, 3], "
+            "random=bytearray(b'random'), "
+            "session_id=bytearray(b'sess'), "
+            "compression=[192], "
+            "extensions=['ext'], "
+            "modifiers=['mod'])",
+            repr(chg))
+
     def test_generate(self):
         state = ConnectionState()
         chg = ClientHelloGenerator()

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -189,6 +189,7 @@
                          "-e", "tls13 signature rsa_pss_pss_sha512"],
           "comment" : "bug tlslite-ng#275"
          },
+         {"name" : "test-tls13-session-resumption.py"},
          {"name" : "test-tls13-signature-algorithms.py"},
          {"name" : "test-tls13-version-negotiation.py"},
          {"name" : "test-tls13-zero-length-data.py"},

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -178,6 +178,7 @@
                          "-e", "tls13 signature rsa_pss_pss_sha512"],
           "comment" : "bug tlslite-ng#275"
          },
+         {"name" : "test-tls13-session-resumption.py"},
          {"name" : "test-tls13-signature-algorithms.py"},
          {"name" : "test-tls13-version-negotiation.py"},
          {"name" : "test-tls13-zero-length-data.py"},

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -459,11 +459,9 @@ class ExpectServerHello(ExpectHandshake):
             return
 
         hrr = state.get_last_message_of_type(ServerHello)
-        if not hrr:
+        if not hrr or hrr.random != TLS_1_3_HRR:
+            # not an HRR, so HRR tests don't apply to it
             return
-
-        if hrr.random != TLS_1_3_HRR:
-            raise ValueError("Two ServerHello messages in TLS 1.3!?")
 
         if hrr.cipher_suite != srv_hello.cipher_suite:
             raise AssertionError("Server picked different cipher suite than "

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -8,6 +8,7 @@ import collections
 import itertools
 from functools import partial
 import sys
+import time
 
 import tlslite.utils.tlshashlib as hashlib
 from tlslite.constants import ContentType, HandshakeType, CertificateType,\
@@ -1033,6 +1034,7 @@ class ExpectNewSessionTicket(ExpectHandshake):
         assert hs_type == HandshakeType.new_session_ticket
 
         ticket = NewSessionTicket().parse(parser)
+        ticket.time = time.time()
 
         state.session_tickets.append(ticket)
 

--- a/tlsfuzzer/helpers.py
+++ b/tlsfuzzer/helpers.py
@@ -166,12 +166,18 @@ def psk_session_ext_gen(psk_settings=None):
 
 def _psk_ext_updater(state, client_hello, psk_settings):
     h_hash = state.handshake_hashes
-    HandshakeHelpers.update_binders(client_hello,
-                                    h_hash,
-                                    psk_settings)
+    nst = None
+    if state.session_tickets:
+        nst = state.session_tickets[-1]
+    HandshakeHelpers.update_binders(
+        client_hello,
+        h_hash,
+        psk_settings,
+        [nst] if nst else None,
+        state.key['resumption master secret'] if nst else None)
 
 
-def psk_ext_updater(psk_settings):
+def psk_ext_updater(psk_settings=tuple()):
     """
     Uses the provided settings to update the PSK binders in CH PSK extension.
 

--- a/tlsfuzzer/helpers.py
+++ b/tlsfuzzer/helpers.py
@@ -107,7 +107,7 @@ def psk_ext_gen(psk_settings):
     default).
 
     :param list psk_settings: list of tuples
-    :return: extension generator
+    :return: extension
     """
     identities = []
     binders = []

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -123,6 +123,11 @@ class ResetHandshakeHashes(Command):
     def process(self, state):
         """Reset current running handshake protocol hashes."""
         state.handshake_hashes = HandshakeHashes()
+        # remove the keys that can interfere with key calculation
+        # don't remove all as we need things like "resumption master secret"
+        # to actually resume next session
+        state.key.pop('PSK secret', None)
+        state.key.pop('DH shared secret', None)
 
 
 class ResetRenegotiationInfo(Command):

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -438,6 +438,28 @@ class ClientHelloGenerator(HandshakeProtocolMessageGenerator):
         self.ssl2 = ssl2
         self.modifiers = modifiers
 
+    def __repr__(self):
+        """Human readable representation of the object."""
+        ret = []
+        if self.ssl2:
+            ret.append("ssl2={0!r}".format(self.ssl2))
+        if self.version:
+            ret.append("version={0!r}".format(self.version))
+        if self.ciphers:
+            ret.append("ciphers={0!r}".format(self.ciphers))
+        if self.random:
+            ret.append("random={0!r}".format(self.random))
+        if self.session_id:
+            ret.append("session_id={0!r}".format(self.session_id))
+        if self.compression:
+            ret.append("compression={0!r}".format(self.compression))
+        if self.extensions:
+            ret.append("extensions={0!r}".format(self.extensions))
+        if self.modifiers:
+            ret.append("modifiers={0!r}".format(self.modifiers))
+
+        return "ClientHelloGenerator({0})".format(", ".join(ret))
+
     def _generate_extensions(self, state):
         """Convert extension generators to extension objects."""
         extensions = []

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -598,8 +598,7 @@ class ClientKeyExchangeGenerator(HandshakeProtocolMessageGenerator):
                 cke = ClientKeyExchange(self.cipher,
                                         self.version).createDH(self.dh_Yc)
             elif self.p_as_share or self.p_1_as_share:
-                ske = next((i for i in reversed(status.handshake_messages)
-                            if isinstance(i, ServerKeyExchange)), None)
+                ske = status.get_last_message_of_type(ServerKeyExchange)
                 assert ske, "No server key exchange in messages"
                 if self.p_as_share:
                     cke = ClientKeyExchange(self.cipher,
@@ -771,8 +770,7 @@ class CertificateVerifyGenerator(HandshakeProtocolMessageGenerator):
         if self.sig_version is None:
             self.sig_version = self.msg_version
         if self.msg_alg is None and self.msg_version >= (3, 3):
-            cert_req = next((msg for msg in status.handshake_messages[::-1]
-                             if isinstance(msg, CertificateRequest)), None)
+            cert_req = status.get_last_message_of_type(CertificateRequest)
             if cert_req is not None:
                 self.msg_alg = next((sig for sig in
                                      cert_req.supported_signature_algs


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Implement support for session resumption in TLS 1.3

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
fixes #184 

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [X] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [X] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [X] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [X] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [X] OpenSSL
  - [x] NSS
  - [x] GnuTLS
- [X] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/427)
<!-- Reviewable:end -->
