### PR TITLE
test-tls13-finished/test-tls13-zero-length-data: allow new session ticket

### DIFF
--- a/scripts/test-tls13-zero-length-data.py
+++ b/scripts/test-tls13-zero-length-data.py
@@ -298,9 +298,16 @@ def main():
     node = node.add_child(ExpectCertificateVerify())
     node = node.add_child(ExpectFinished())
     node = node.add_child(ApplicationDataGenerator(bytearray(0)))
-    node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                      AlertDescription.unexpected_message))
-    node.add_child(ExpectClose())
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectAlert(AlertLevel.fatal,
+                                    AlertDescription.unexpected_message)
+    node.next_sibling.add_child(ExpectClose())
+
     conversations["zero-length app data during handshake"] = conversation
 
     # Send zero-length application data while handshaking with padding
@@ -332,9 +339,16 @@ def main():
     node = node.add_child(SetPaddingCallback(
         SetPaddingCallback.fixed_length_cb(30)))
     node = node.add_child(ApplicationDataGenerator(bytearray(0)))
-    node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                      AlertDescription.unexpected_message))
-    node.add_child(ExpectClose())
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectAlert(AlertLevel.fatal,
+                                    AlertDescription.unexpected_message)
+    node.next_sibling.add_child(ExpectClose())
+
     conversations["zero-length app data with padding during handshake"] =\
         conversation
 


### PR DESCRIPTION
### Description

Previously the tests 'zero-length app data with padding during handshake' and 'zero-length app data during handshake' would fail if a session ticket would be received.


- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [x] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/429)
<!-- Reviewable:end -->
