### PR TITLE
test-large-hello - don't send TLS 1.3 extensions in the test

### DIFF
--- a/scripts/test-large-hello.py
+++ b/scripts/test-large-hello.py
@@ -34,7 +34,7 @@ def help_msg():
     print("                may be specified multiple times")
     print(" -n num         only run `num` random tests instead of a full set")
     print("                (excluding \"sanity\" tests)")
-    print(" -m min-ext-no  the minimum extension number to use (default=50)")
+    print(" -m min-ext-no  the minimum extension number to use (default=52)")
     print("                (the test uses random extensions past this number)")
     print(" --help         this message")
 
@@ -43,7 +43,7 @@ def main():
     host = "localhost"
     port = 4433
     num_limit = None
-    min_ext = 50
+    min_ext = 52
     run_exclude = set()
 
     argv = sys.argv[1:]
@@ -188,12 +188,14 @@ def main():
         high_num_ext = (ExtensionType.supports_npn,
                         ExtensionType.tack,
                         ExtensionType.renegotiation_info)
+        # increase the count if some extension points will be skipped because
+        # they are meaningful
         for num in high_num_ext:
             if i+min_ext > num:
                 i+=1
-        ext = dict((i, TLSExtension(extType=i))
-                    for i in range(min_ext, min_ext+i)
-                    if i not in high_num_ext)
+        ext = dict((j, TLSExtension(extType=j))
+                    for j in range(min_ext, min_ext+i)
+                    if j not in high_num_ext)
         node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
         node = node.add_child(ExpectServerHello())
         node = node.add_child(ExpectCertificate())


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
51 is key_share from TLS 1.3, which may cause confusion in the server
(which is not the purpose of this test); increase the minimal extension
id to fix it

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
fixes #413 

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a no functional change, if anything the test is becoming less strict
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/438)
<!-- Reviewable:end -->
