### PR TITLE
make the test-tls13-finished.py more robust, report better errors when it fails

### DIFF
--- a/tests/test_tlsfuzzer_runner.py
+++ b/tests/test_tlsfuzzer_runner.py
@@ -217,8 +217,27 @@ class TestRunner(unittest.TestCase):
         runner.state.msg_sock.recvMessageBlocking = \
                 mock.MagicMock(side_effect=TLSAbruptCloseError())
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(AssertionError) as e:
             runner.run()
+
+        self.assertIn("Unexpected closure from peer", str(e.exception))
+
+    def test_run_with_expect_and_read_timeout(self):
+        node = mock.MagicMock()
+        node.is_command = mock.Mock(return_value=False)
+        node.is_expect = mock.Mock(return_value=True)
+        node.is_generator = mock.Mock(return_value=False)
+        node.child = None
+
+        runner = Runner(node)
+        runner.state.msg_sock = mock.MagicMock()
+        runner.state.msg_sock.recvMessageBlocking = \
+                mock.MagicMock(side_effect=socket.timeout())
+
+        with self.assertRaises(AssertionError) as e:
+            runner.run()
+
+        self.assertIn("Timeout when waiting", str(e.exception))
 
     def test_run_with_expect_and_no_message(self):
         node = ExpectNoMessage()

--- a/tlsfuzzer/runner.py
+++ b/tlsfuzzer/runner.py
@@ -193,7 +193,12 @@ class Runner(object):
                             node = close_node.child
                             continue
                         else:
-                            raise AssertionError("Unexpected closure from peer")
+                            if isinstance(exc, socket.timeout):
+                                raise AssertionError(
+                                    "Timeout when waiting for peer message")
+                            else:
+                                raise AssertionError(
+                                    "Unexpected closure from peer")
                     msg = Message(header.type, parser.bytes)
                     old_node = node
 

--- a/tlsfuzzer/runner.py
+++ b/tlsfuzzer/runner.py
@@ -177,7 +177,8 @@ class Runner(object):
                         self.state.msg_sock.sock.settimeout(node.timeout)
                     # check peer response
                     try:
-                        header, parser = self.state.msg_sock.recvMessageBlocking()
+                        header, parser = self.state.msg_sock.\
+                            recvMessageBlocking()
                     except (TLSAbruptCloseError, socket.error) as exc:
                         if isinstance(exc, socket.timeout) and \
                                 isinstance(node, ExpectNoMessage):
@@ -186,8 +187,9 @@ class Runner(object):
                             self.state.msg_sock.sock.settimeout(old_timeout)
                             node = node.child
                             continue
-                        close_node = next((n for n in node.get_all_siblings() \
-                                           if isinstance(n, ExpectClose)), None)
+                        close_node = next((n for n in node.get_all_siblings()
+                                           if isinstance(n, ExpectClose)),
+                                          None)
                         if close_node:
                             close_node.process(self.state, None)
                             node = close_node.child


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Increase the timeout for the test case that sends 16MiB before aborting

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
fixes #439

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a, no functional changes
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/444)
<!-- Reviewable:end -->
