### PR TITLE
scripts: tolerate NST before sending client Finished

### DIFF
--- a/scripts/test-tls13-zero-length-data.py
+++ b/scripts/test-tls13-zero-length-data.py
@@ -395,9 +395,16 @@ def main():
     node = node.add_child(SetPaddingCallback(
         SetPaddingCallback.fill_padding_cb))
     node = node.add_child(ApplicationDataGenerator(bytearray(0)))
-    node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                      AlertDescription.unexpected_message))
-    node.add_child(ExpectClose())
+
+    # The server may send NST before receiving client Finished
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectAlert(AlertLevel.fatal,
+                                    AlertDescription.unexpected_message)
+    node.next_sibling.add_child(ExpectClose())
     conversations["zero-len app data with large padding during handshake"] =\
         conversation
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Since [this MR](https://gitlab.com/gnutls/gnutls/merge_requests/711), GnuTLS started to send NST before receiving client Finished. This breaks the assumption that `test-tls13-zero-length-data.py` expects "unexpect_message" alert.

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
https://gitlab.com/gnutls/gnutls/merge_requests/708#note_92694140

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [x] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/446)
<!-- Reviewable:end -->
