### PR TITLE
verify extentions in EE tls13 message

### DIFF
--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -1606,6 +1606,127 @@ class TestExpectEncryptedExtensions(unittest.TestCase):
 
         self.assertIn(ee, state.handshake_messages)
 
+    def test_process_with_extensions(self):
+        groups = [GroupName.secp256r1]
+        sup_group_ext = SupportedGroupsExtension().create(groups)
+        ext = {ExtensionType.supported_groups: sup_group_ext}
+
+        exp = ExpectEncryptedExtensions(extensions=ext)
+
+        ee = EncryptedExtensions().create([sup_group_ext])
+
+        state = ConnectionState()
+
+        exp.process(state, ee)
+
+        self.assertIn(ee, state.handshake_messages)
+
+    def test_process_with_unsupported_extensions(self):
+        key_shares = [key_share_gen(GroupName.secp256r1)]
+        key_share_ext = ClientKeyShareExtension().create(key_shares)
+
+        exp = ExpectEncryptedExtensions()
+
+        ee = EncryptedExtensions().create([key_share_ext])
+
+        state = ConnectionState()
+
+        with self.assertRaises(AssertionError):
+            exp.process(state, ee)
+
+    def test_process_with_missing_extensions(self):
+        sup_group_ext = SupportedGroupsExtension().create(
+            [GroupName.secp256r1])
+        ext = {ExtensionType.supported_groups: sup_group_ext}
+
+        exp = ExpectEncryptedExtensions(extensions=ext)
+
+        ee = EncryptedExtensions().create([])
+
+        state = ConnectionState()
+
+        with self.assertRaises(AssertionError):
+            exp.process(state, ee)
+
+    def test_process_with_extra_extensions(self):
+        sup_group_ext = SupportedGroupsExtension().create(
+            [GroupName.secp256r1])
+        sni_ext = SNIExtension().create(bytearray('localhost', 'utf-8'))
+        ext = {ExtensionType.supported_groups: sup_group_ext}
+
+        exp = ExpectEncryptedExtensions(extensions=ext)
+
+        ee = EncryptedExtensions().create([sup_group_ext, sni_ext])
+
+        state = ConnectionState()
+
+        with self.assertRaises(AssertionError):
+            exp.process(state, ee)
+
+    def test_process_with_missing_specified_extension(self):
+        sup_group_ext = SupportedGroupsExtension().create(
+            [GroupName.secp256r1])
+        sni_ext = SNIExtension().create(bytearray('localhost', 'utf-8'))
+        ext = {ExtensionType.supported_groups: sup_group_ext,
+               ExtensionType.server_name: sni_ext}
+
+        exp = ExpectEncryptedExtensions(extensions=ext)
+
+        ee = EncryptedExtensions().create([sup_group_ext])
+
+        state = ConnectionState()
+
+        with self.assertRaises(AssertionError):
+            exp.process(state, ee)
+
+    def test_process_with_no_autohandler(self):
+        sup_group_ext = SupportedGroupsExtension().create(
+            [GroupName.secp256r1])
+        ext = {ExtensionType.supported_groups: sup_group_ext}
+
+        exp = ExpectEncryptedExtensions()
+
+        ee = EncryptedExtensions().create([sup_group_ext])
+
+        state = ConnectionState()
+
+        with self.assertRaises(AssertionError):
+            exp.process(state, ee)
+
+    def test_process_with_non_matching_example(self):
+        sup_group_ext = SupportedGroupsExtension().create(
+            [GroupName.secp256r1])
+        ext = {ExtensionType.supported_groups: sup_group_ext}
+
+        exp = ExpectEncryptedExtensions(extensions=ext)
+
+        ee = EncryptedExtensions().create([SupportedGroupsExtension().create(
+            [GroupName.secp521r1])])
+
+        state = ConnectionState()
+
+        with self.assertRaises(AssertionError):
+            exp.process(state, ee)
+
+    def test_process_with_bad_extension_handler(self):
+        sup_group_ext = SupportedGroupsExtension().create(
+            [GroupName.secp256r1])
+        ext = {ExtensionType.supported_groups: sup_group_ext,
+               ExtensionType.alpn: 'BAD_EXTENSION'}
+
+        exp = ExpectEncryptedExtensions(extensions=ext)
+
+        ee_ext = []
+        ee_ext.append(sup_group_ext)
+        ee_ext.append(ALPNExtension().create([bytearray(b'http/1.1')]))
+
+        ee = EncryptedExtensions().create(ee_ext)
+
+        state = ConnectionState()
+
+        with self.assertRaises(ValueError):
+            exp.process(state, ee)
+
 
 class TestExpectNewSessionTicket(unittest.TestCase):
     def test___init__(self):

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -1014,18 +1014,105 @@ class ExpectEncryptedExtensions(ExpectHandshake):
             HandshakeType.encrypted_extensions)
         self.extensions = extensions
 
+    def _compare_extensions(self, srv_exts):
+        """
+        Verify that server provided extensions match exactly expected list.
+        """
+        # check if received extensions match the set extensions
+        if self.extensions and not srv_exts.extensions:
+            raise AssertionError("Server did not send any extensions")
+        elif self.extensions and srv_exts.extensions:
+            expected = set(self.extensions.keys())
+            got = set(i.extType for i in srv_exts.extensions)
+            if got != expected:
+                diff = expected.difference(got)
+                if diff:
+                    raise AssertionError("Server did not send extension(s): "
+                                         "{0}".format(
+                                             ", ".join(ExtensionType.toStr(i)
+                                                       for i in diff)))
+                diff = got.difference(expected)
+                if diff:
+                    raise AssertionError("Server sent unexpected extension(s): "
+                                         "{0}".format(
+                                             ", ".join(ExtensionType.toStr(i)
+                                                       for i in diff)))
+
+    @staticmethod
+    def _get_autohandler(ext_id):
+        try:
+            return _srv_ext_handler[ext_id]
+        except KeyError:
+            raise AssertionError("No autohandler for "
+                                 "{0}"
+                                 .format(ExtensionType
+                                         .toStr(ext_id)))
+
+    def _process_extensions(self, state, srv_exts):
+        """Check if extensions are correct."""
+        ee_supported = [ExtensionType.server_name,
+                        1,  # max_fragment_length - RFC 6066
+                        ExtensionType.supported_groups,
+                        14,  # use_srtp - RFC 5764
+                        15,  # heartbeat - RFC 6520
+                        ExtensionType.alpn,
+                        19,  # client_certificate_type - draft-ietf-tls-tls13-28 / RFC 7250
+                        20,  # server_certificate_type - draft-ietf-tls-tls13-28 / RFC 7250
+                        ExtensionType.early_data]
+        tlslite_supported = [ExtensionType.server_name,
+                             ExtensionType.supported_groups,
+                             ExtensionType.alpn,
+                             ExtensionType.early_data]
+
+        for ext in srv_exts.extensions:
+            ext_id = ext.extType
+            if not ext_id in ee_supported:
+                raise AssertionError("Server sent unsupported "
+                                     "extension of type {0}"
+                                     .format(ExtensionType
+                                             .toStr(ext_id)))
+            if ext_id in tlslite_supported:
+                handler = None
+                if self.extensions:
+                    try:
+                        handler = self.extensions[ext_id]
+                    except KeyError:
+                        raise AssertionError("Unexpected extension from "
+                                             "server of type {0}"
+                                             .format(ExtensionType
+                                                     .toStr(ext_id)))
+                # use automatic handlers for some extensions
+                if handler is None:
+                    handler = self._get_autohandler(ext_id)
+
+                if callable(handler):
+                    handler(state, ext)
+                elif isinstance(handler, TLSExtension):
+                    if not handler == ext:
+                        raise AssertionError("Expected extension not "
+                                             "matched for type {0}, "
+                                             "received: {1}"
+                                             .format(ExtensionType
+                                                     .toStr(ext_id),
+                                                     ext))
+                else:
+                    raise ValueError("Bad extension handler for id {0}"
+                                     .format(ExtensionType.toStr(ext_id)))
+
     def process(self, state, msg):
         assert msg.contentType == ContentType.handshake
         parser = Parser(msg.write())
         hs_type = parser.get(1)
         assert hs_type == self.handshake_type
 
-        exts = EncryptedExtensions().parse(parser)
+        srv_exts = EncryptedExtensions().parse(parser)
 
-        # TODO check if received extensions match the set extensions
-        assert self.extensions is None
+        if srv_exts.extensions:
+            self._process_extensions(state, srv_exts)
 
-        state.handshake_messages.append(exts)
+        self._compare_extensions(srv_exts)
+
+        state.handshake_messages.append(srv_exts)
         state.handshake_hashes.update(msg.write())
 
 


### PR DESCRIPTION
### Description
Now the expect.py module verify that the recieved extentions are same as we expect for EE message.

### Motivation and Context
fixes #192 

### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [x] NSS
  - [x] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md