### PR TITLE
fix requirements for python-2.6 build

### DIFF
--- a/build-requirements-2.6.txt
+++ b/build-requirements-2.6.txt
@@ -1,3 +1,4 @@
+pycparser<2.19
 isort<4.3
 inflect<0.3.1
 pyopenssl<18


### PR DESCRIPTION
### Description
As `pycparser` package droped support for python-2.6 in new release, we need to use older release.

### Motivation and Context
fix Travic CI builds for python-2.6

### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/463)
<!-- Reviewable:end -->
