### PR TITLE
New test-script for tls1.3 with shuffled extensions

### DIFF
--- a/scripts/test-tls13-shuffled-extentions.py
+++ b/scripts/test-tls13-shuffled-extentions.py
@@ -1,0 +1,287 @@
+# Author: Robert Kolcun, (c) 2018
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+from itertools import chain, islice
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+        ch_cookie_handler
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+        ExpectAlert, ExpectApplicationData, ExpectClose, \
+        ExpectEncryptedExtensions, ExpectCertificateVerify, \
+        ExpectNewSessionTicket, ExpectHelloRetryRequest
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+from tlslite.keyexchange import ECDHKeyExchange
+from tlsfuzzer.utils.lists import natural_sort_keys
+from tlsfuzzer.utils.ordered_dict import OrderedDict
+from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
+        SupportedVersionsExtension, SupportedGroupsExtension, \
+        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, AutoEmptyExtension
+
+
+version = 1
+
+
+def help_msg():
+    print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
+    print(" -h hostname    name of the host to run the test against")
+    print("                localhost by default")
+    print(" -p port        port number to use for connection, 4433 by default")
+    print(" probe-name     if present, will run only the probes with given")
+    print("                names and not all of them, e.g \"sanity\"")
+    print(" -e probe-name  exclude the probe from the list of the ones run")
+    print("                may be specified multiple times")
+    print(" -n num         only run `num` random tests instead of a full set")
+    print("                (excluding \"sanity\" tests)")
+    print(" --exc ext-id   exclude specific extenion id from a list")
+    print("                of unassigned extenions,")
+    print("                may be specified multiple times")
+    print(" --cookie       expect the server to send \"cookie\" extension in")
+    print("                Hello Retry Request message")
+    print(" --help         this message")
+
+
+def main():
+    host = "localhost"
+    port = 4433
+    num_limit = None
+    run_exclude = set()
+    ext_exclude = set()
+    cookie = False
+
+    argv = sys.argv[1:]
+    opts, args = getopt.getopt(argv, "h:p:e:n:", ["help", "cookie", "exc="])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '-e':
+            run_exclude.add(arg)
+        elif opt == '-n':
+            num_limit = int(arg)
+        elif opt == '--exc':
+            ext_exclude.add(int(arg))
+        elif opt == '--cookie':
+            cookie = True
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+
+    if args:
+        run_only = set(args)
+    else:
+        run_only = None
+
+    conversations = {}
+
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        .create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        .create(RSA_SIG_ALL)
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                       AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+    conversations["sanity"] = conversation
+
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = OrderedDict()
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        .create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        .create(RSA_SIG_ALL)
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+
+    hrr_ext = OrderedDict()
+    if cookie:
+        hrr_ext[ExtensionType.cookie] = None
+    hrr_ext[ExtensionType.key_share] = None
+    hrr_ext[ExtensionType.supported_versions] = None
+    node = node.add_child(ExpectHelloRetryRequest(extensions=hrr_ext))
+    node = node.add_child(ExpectChangeCipherSpec())
+
+    # Reverse extensions
+    rev_ext = OrderedDict()
+    rev_ext.update(reversed(ext.items()))
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    rev_ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    if cookie:
+        rev_ext[ExtensionType.cookie] = ch_cookie_handler
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=rev_ext))
+    node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                      AlertDescription.illegal_parameter))
+    node.add_child(ExpectClose())
+    conversations["HRR reversed order of known extensions"] = conversation
+
+    unassigned_ext_id = list(range(52, 65279))
+
+    # Exclude extensions from a list of unassigned ones
+    unassigned_ext_id = [ext for ext in unassigned_ext_id if ext not in ext_exclude]
+
+    chunk_size = 4096
+    for ext_chunk in (unassigned_ext_id[j:j + chunk_size]
+                      for j in range(0, len(unassigned_ext_id), chunk_size)):
+        conversation = Connect(host, port)
+        node = conversation
+        ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+        ext = OrderedDict()
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            .create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            .create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256]
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+            .create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+            .create(RSA_SIG_ALL)
+        for ext_id in ext_chunk:
+            ext[ext_id] = AutoEmptyExtension()
+        node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+
+        hrr_ext = OrderedDict()
+        if cookie:
+            hrr_ext[ExtensionType.cookie] = None
+        hrr_ext[ExtensionType.key_share] = None
+        hrr_ext[ExtensionType.supported_versions] = None
+        node = node.add_child(ExpectHelloRetryRequest(extensions=hrr_ext))
+        node = node.add_child(ExpectChangeCipherSpec())
+
+        # Reverse extensions
+        rev_ext = OrderedDict()
+        rev_ext.update(reversed(ext.items()))
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        rev_ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+        if cookie:
+            rev_ext[ExtensionType.cookie] = ch_cookie_handler
+        node = node.add_child(ClientHelloGenerator(ciphers, extensions=rev_ext))
+        node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                          AlertDescription.illegal_parameter))
+        node.add_child(ExpectClose())
+
+        conversations["HRR reversed order of unassigned extensions, ext_ids in range from {0} to {1}".format(
+            ext_chunk[0], ext_chunk[-1])] = conversation
+
+    # run the conversation
+    good = 0
+    bad = 0
+    failed = []
+    if not num_limit:
+        num_limit = len(conversations)
+
+    # make sure that sanity test is run first and last
+    # to verify that server was running and kept running throught
+    sanity_test = ('sanity', conversations['sanity'])
+    ordered_tests = chain([sanity_test],
+                          islice(filter(lambda x: x[0] != 'sanity',
+                                        conversations.items()), num_limit),
+                          [sanity_test])
+
+    for c_name, c_test in ordered_tests:
+        if run_only and c_name not in run_only or c_name in run_exclude:
+            continue
+        print("{0} ...".format(c_name))
+
+        runner = Runner(c_test)
+
+        res = True
+        try:
+            runner.run()
+        except Exception:
+            print("Error while processing")
+            print(traceback.format_exc())
+            res = False
+
+        if res:
+            good += 1
+            print("OK\n")
+        else:
+            bad += 1
+            failed.append(c_name)
+
+    print("TLS 1.3 communication with shuffled extensions in CH messages.")
+    print("Verify that server reject second CH message,")
+    print("when the order of extensions in first and second CH is different.")
+    print("Also unassigned extensions are used.\n")
+    print("version: {0}\n".format(version))
+
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+    failed_sorted = sorted(failed, key=natural_sort_keys)
+    print("  {0}".format('\n  '.join(repr(i) for i in failed_sorted)))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -222,6 +222,8 @@
          {"name" : "test-tls13-serverhello-random.py",
           "arguments" : ["--repeat", "5"]},
          {"name" : "test-tls13-session-resumption.py"},
+         {"name" : "test-tls13-shuffled-extentions.py",
+          "arguments" : ["--cookie"]},
          {"name" : "test-tls13-signature-algorithms.py",
           "arguments" : ["-n", "100"]},
          {"name" : "test-tls13-unrecognised-groups.py",

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -207,6 +207,8 @@
          },
          {"name" : "test-tls13-serverhello-random.py"},
          {"name" : "test-tls13-session-resumption.py"},
+         {"name" : "test-tls13-shuffled-extentions.py",
+          "arguments" : ["--cookie"]},
          {"name" : "test-tls13-signature-algorithms.py"},
          {"name" : "test-tls13-version-negotiation.py"},
          {"name" : "test-tls13-zero-length-data.py"},


### PR DESCRIPTION
### Description
New test-script for tls1.3 with HRR message in communication.
Script verify that the communication is rejected after second ClientHello, when first & second ClientHello message contain different order of same extensions.

### Motivation and Context
fixes #398 

### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [x] NSS
  - [x] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/469)
<!-- Reviewable:end -->
