### PR TITLE
new node to reset writeState encryption of a connection

### DIFF
--- a/tests/test_tlsfuzzer_messages.py
+++ b/tests/test_tlsfuzzer_messages.py
@@ -28,7 +28,8 @@ from tlsfuzzer.messages import ClientHelloGenerator, ClientKeyExchangeGenerator,
         TCPBufferingFlush, fuzz_encrypted_message, fuzz_pkcs1_padding, \
         CollectNonces, AlertGenerator, PlaintextMessageGenerator, \
         SetPaddingCallback, replace_plaintext, ch_cookie_handler, \
-        ch_key_share_handler, SetRecordVersion, CopyVariables
+        ch_key_share_handler, SetRecordVersion, CopyVariables, \
+        ResetWriteConnectionState
 from tlsfuzzer.helpers import psk_ext_gen, psk_ext_updater, \
         psk_session_ext_gen, AutoEmptyExtension
 from tlsfuzzer.runner import ConnectionState
@@ -140,6 +141,41 @@ class TestTCPBufferingFlush(unittest.TestCase):
 
         raw_sock.return_value.sendall.assert_called_once_with(
                 bytearray(b'\x0c\x03\x00\x00\x01\xff'))
+
+
+class TestResetWriteConnectionState(unittest.TestCase):
+    def test__init__(self):
+        node = ResetWriteConnectionState()
+
+        self.assertIsNotNone(node)
+        self.assertTrue(node.is_command())
+        self.assertFalse(node.is_expect())
+        self.assertFalse(node.is_generator())
+
+    def test_process(self):
+        state = ConnectionState()
+        state.msg_sock = mock.MagicMock()
+
+        self.assertIsNotNone(state.msg_sock._writeState.macContext)
+        self.assertIsNotNone(state.msg_sock._writeState.encContext)
+        self.assertIsNotNone(state.msg_sock._writeState.fixedNonce)
+        self.assertIsNotNone(state.msg_sock._writeState.seqnum)
+        self.assertIsNotNone(state.msg_sock._writeState.encryptThenMAC)
+
+        node = ResetWriteConnectionState()
+        node.process(state)
+
+        self.assertIsNotNone(state.msg_sock._readState.macContext)
+        self.assertIsNotNone(state.msg_sock._readState.encContext)
+        self.assertIsNotNone(state.msg_sock._readState.fixedNonce)
+        self.assertIsNotNone(state.msg_sock._readState.seqnum)
+        self.assertIsNotNone(state.msg_sock._readState.encryptThenMAC)
+
+        self.assertIsNone(state.msg_sock._writeState.macContext)
+        self.assertIsNone(state.msg_sock._writeState.encContext)
+        self.assertIsNone(state.msg_sock._writeState.fixedNonce)
+        self.assertEqual(state.msg_sock._writeState.seqnum, 0)
+        self.assertFalse(state.msg_sock._writeState.encryptThenMAC)
 
 
 class TestCollectNonces(unittest.TestCase):

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -24,6 +24,7 @@ from tlslite.utils.cryptomath import getRandomBytes, numBytes, \
     derive_secret
 from tlslite.keyexchange import KeyExchange
 from tlslite.bufferedsocket import BufferedSocket
+from tlslite.recordlayer import ConnectionState
 from .helpers import key_share_gen, AutoEmptyExtension
 from .handshake_helpers import calc_pending_states
 from .tree import TreeNode
@@ -244,6 +245,17 @@ class TCPBufferingFlush(Command):
     def process(self, state):
         """Flush all messages to TCP socket."""
         state.msg_sock.sock.flush()
+
+
+class ResetWriteConnectionState(Command):
+    """
+    Reset _writeState configuration to default values
+
+    All sent messages will be unencrypted now
+    """
+
+    def process(self, state):
+        state.msg_sock._writeState = ConnectionState()
 
 
 class CollectNonces(Command):


### PR DESCRIPTION
### Description
New node, which reset _writeState in a socket to default values, so the next messages that are sent will be unencrypted.

### Motivation and Context
Necessary for testing https://github.com/tomato42/tlsfuzzer/pull/472

### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [x] NSS
  - [x] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md
