### PR TITLE
change requirements for python 2.6 (idna package)

### DIFF
--- a/build-requirements-2.6.txt
+++ b/build-requirements-2.6.txt
@@ -7,3 +7,4 @@ coverage
 coveralls<1.3.0
 pylint
 diff_cover
+idna<2.8


### PR DESCRIPTION
### Description
Package idna droped support for python 2.6 & 3.3 (https://github.com/kjd/idna/commit/2618ad17c86498d627ebb136143c2799ad48cbe3) in the last release 2.8. This PR updates the build-requirements for python 2.6.

### Motivation and Context
Failed build in Travis CI https://travis-ci.org/tomato42/tlsfuzzer/jobs/463888341

### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [x] NSS
  - [x] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/478)
<!-- Reviewable:end -->
