### PR TITLE
fix test names in rsa-pss-sigs-cv test-script

### DIFF
--- a/scripts/test-rsa-pss-sigs-on-certificate-verify.py
+++ b/scripts/test-rsa-pss-sigs-on-certificate-verify.py
@@ -356,8 +356,8 @@ def main():
         node = node.add_child(ExpectAlert())
         node.next_sibling = ExpectClose()
         node = node.add_child(ExpectClose())
-        conversations["{0} in CertificateVerify"
-                      .format(SignatureScheme.toRepr(scheme))] = conversation
+        conversations["{0} in CertificateVerify with {1} key"
+                      .format(SignatureScheme.toRepr(scheme), cert.certAlg)] = conversation
 
     # check if CertificateVerify with wrong salt size is rejected
     for scheme in schemes:
@@ -445,9 +445,8 @@ def main():
                                               AlertDescription.decrypt_error))
             node.next_sibling = ExpectClose()
             node = node.add_child(ExpectClose())
-            conversations_long["malformed rsa-pss in CertificateVerify - "
-                          "xor {1} at {0}"
-                          .format(pos, hex(xor))] = conversation
+            conversations_long["malformed {0} in CertificateVerify - xor {1} at {2}"
+                               .format(cert.certAlg, hex(xor), pos)] = conversation
 
     if cert.certAlg == "rsa-pss":
         conversation = Connect(host, port)
@@ -539,8 +538,8 @@ def main():
                                           AlertDescription.decrypt_error))
     node.next_sibling = ExpectClose()
     node = node.add_child(ExpectClose())
-    conversations["rsa_pss_rsae_sha256 signature in CertificateVerify "
-                  "with rsa_pkcs1_sha256 id"] = conversation
+    conversations["{0} signature in CertificateVerify with rsa_pkcs1_sha256 id"
+                  .format(SignatureScheme.toRepr(sig_alg))] = conversation
 
     conversation = Connect(host, port)
     node = conversation
@@ -584,8 +583,8 @@ def main():
                                       AlertDescription.decrypt_error))
     node.next_sibling = ExpectClose()
     node = node.add_child(ExpectClose())
-    conversations["short sig with rsa_pss_rsae_sha256 id"] = \
-                  conversation
+    conversations["short sig with {0} id".format(
+                  SignatureScheme.toRepr(scheme))] = conversation
 
     # run the conversation
     good = 0


### PR DESCRIPTION
### Description
When we updated tests in `test-rsa-pss-sigs-on-certificate-verify.py` (https://github.com/tomato42/tlsfuzzer/pull/470). We forgot to include name of used key and sig. scheme in CV msg in test name. This PR should fix it.

### Motivation and Context
Fix test names, so we know what we are testing when we run the test-script.

### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [x] NSS
  - [x] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/486)
<!-- Reviewable:end -->
