### PR TITLE
rsa-pss-sigs-on-certificate-verify - be strict with receiving alerts

### DIFF
--- a/scripts/test-rsa-pss-sigs-on-certificate-verify.py
+++ b/scripts/test-rsa-pss-sigs-on-certificate-verify.py
@@ -298,12 +298,15 @@ def main():
         node = node.add_child(ExpectServerKeyExchange())
         node = node.add_child(ExpectCertificateRequest())
         node = node.add_child(ExpectServerHelloDone())
+        node = node.add_child(TCPBufferingEnable())
         node = node.add_child(CertificateGenerator(X509CertChain([cert])))
         node = node.add_child(ClientKeyExchangeGenerator())
         node = node.add_child(CertificateVerifyGenerator(private_key,
                                                          msg_alg=scheme))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
+        node = node.add_child(TCPBufferingDisable())
+        node = node.add_child(TCPBufferingFlush())
         if exp_illeg_param:
             node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                               AlertDescription.illegal_parameter))

--- a/scripts/test-rsa-pss-sigs-on-certificate-verify.py
+++ b/scripts/test-rsa-pss-sigs-on-certificate-verify.py
@@ -310,7 +310,6 @@ def main():
         else:
             node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                               AlertDescription.decrypt_error))
-        node.next_sibling = ExpectClose()
         node = node.add_child(ExpectClose())
         conversations["{0} in CertificateVerify with {1} key"
                       .format(SignatureScheme.toRepr(scheme), cert.certAlg)] = conversation
@@ -396,7 +395,6 @@ def main():
         node = node.add_child(TCPBufferingFlush())
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.decrypt_error))
-        node.next_sibling = ExpectClose()
         node = node.add_child(ExpectClose())
         conversations["{0} in CertificateVerify with incorrect salt len"
                       .format(SignatureScheme.toRepr(scheme))] = conversation
@@ -443,7 +441,6 @@ def main():
             node = node.add_child(TCPBufferingFlush())
             node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                               AlertDescription.decrypt_error))
-            node.next_sibling = ExpectClose()
             node = node.add_child(ExpectClose())
             conversations_long["malformed {0} in CertificateVerify - xor {1} at {2}"
                                .format(cert.certAlg, hex(xor), pos)] = conversation
@@ -488,7 +485,6 @@ def main():
         else:
             node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                               AlertDescription.decrypt_error))
-        node.next_sibling = ExpectClose()
         node = node.add_child(ExpectClose())
         conversations["rsa_pkcs1_sha256 signature in CertificateVerify "
                       "with rsa-pss key"] = conversation
@@ -536,7 +532,6 @@ def main():
     else:
         node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                           AlertDescription.decrypt_error))
-    node.next_sibling = ExpectClose()
     node = node.add_child(ExpectClose())
     conversations["{0} signature in CertificateVerify with rsa_pkcs1_sha256 id"
                   .format(SignatureScheme.toRepr(sig_alg))] = conversation
@@ -581,7 +576,6 @@ def main():
     node = node.add_child(TCPBufferingFlush())
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
                                       AlertDescription.decrypt_error))
-    node.next_sibling = ExpectClose()
     node = node.add_child(ExpectClose())
     conversations["short sig with {0} id".format(
                   SignatureScheme.toRepr(scheme))] = conversation


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
make sure that the other side does send alerts and doesn't just close
connection on errors

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
increase strictness of checks – no point in checking alert descriptions if we ignore missing alert

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [x] NSS
  - [x] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/490)
<!-- Reviewable:end -->
