### PR TITLE
Add test to check tls13 client certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You'll need:
 
  * Python 2.6 or later or Python 3.2 or later
  * [tlslite-ng](https://github.com/tomato42/tlslite-ng)
-   0.8.0-alpha20 or later (note that `tlslite` will *not* work and
+   0.8.0-alpha23 or later (note that `tlslite` will *not* work and
    they conflict with each other)
  * [ecdsa](https://github.com/warner/python-ecdsa)
    python module (dependency of tlslite-ng, should get installed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tlslite-ng>=0.8.0-alpha21
+tlslite-ng>=0.8.0-alpha23

--- a/scripts/test-tls13-certificate-request.py
+++ b/scripts/test-tls13-certificate-request.py
@@ -1,0 +1,303 @@
+# Author: Simo Sorce, (c) 2018
+# Released under Gnu GPL v2.0, see LICENSE file for details
+"""Test with CertificateRequest"""
+
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+import re
+from itertools import chain
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, \
+        CertificateGenerator, CertificateVerifyGenerator, \
+        AlertGenerator
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+        ExpectAlert, ExpectClose, ExpectCertificateRequest, \
+        ExpectApplicationData, ExpectEncryptedExtensions, \
+        ExpectCertificateVerify, ExpectNewSessionTicket
+from tlsfuzzer.utils.lists import natural_sort_keys
+from tlsfuzzer.helpers import key_share_gen, sig_algs_to_ids, RSA_SIG_ALL
+from tlslite.extensions import SignatureAlgorithmsExtension, \
+        SignatureAlgorithmsCertExtension, ClientKeyShareExtension, \
+        SupportedVersionsExtension, SupportedGroupsExtension
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+        HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme, \
+        GroupName
+from tlslite.utils.keyfactory import parsePEMKey
+from tlslite.x509 import X509
+from tlslite.x509certchain import X509CertChain
+
+
+version = 1
+
+
+def help_msg():
+    print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
+    print(" -h hostname    name of the host to run the test against")
+    print("                localhost by default")
+    print(" -p port        port number to use for connection, 4433 by default")
+    print(" probe-name     if present, will run only the probes with given")
+    print("                names and not all of them, e.g \"sanity\"")
+    print(" -e probe-name  exclude the probe from the list of the ones run")
+    print("                may be specified multiple times")
+    print(" -s sigalgs     hash and signature algorithm pairs that the server")
+    print("                is expected to support.")
+    print(" -k keyfile     file with private key of client")
+    print(" -c certfile    file with the certificate of client")
+    print(" --help         this message")
+
+
+def main():
+    """Check what signature algorithms server advertises"""
+    hostname = "localhost"
+    port = 4433
+    run_exclude = set()
+    cert = None
+    private_key = None
+
+    sigalgs = [SignatureScheme.rsa_pss_rsae_sha512,
+               SignatureScheme.rsa_pss_pss_sha512,
+               SignatureScheme.rsa_pss_rsae_sha384,
+               SignatureScheme.rsa_pss_pss_sha384,
+               SignatureScheme.rsa_pss_rsae_sha256,
+               SignatureScheme.rsa_pss_pss_sha256,
+               SignatureScheme.rsa_pkcs1_sha512,
+               SignatureScheme.rsa_pkcs1_sha384,
+               SignatureScheme.rsa_pkcs1_sha256,
+               SignatureScheme.rsa_pkcs1_sha224,
+               SignatureScheme.rsa_pkcs1_sha1]
+
+    argv = sys.argv[1:]
+    opts, args = getopt.getopt(argv, "h:p:e:s:k:c:", ["help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '-e':
+            run_exclude.add(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        elif opt == '-s':
+            sigalgs = sig_algs_to_ids(arg)
+        elif opt == '-k':
+            text_key = open(arg, 'rb').read()
+            if sys.version_info[0] >= 3:
+                text_key = str(text_key, 'utf-8')
+            private_key = parsePEMKey(text_key, private=True)
+        elif opt == '-c':
+            text_cert = open(arg, 'rb').read()
+            if sys.version_info[0] >= 3:
+                text_cert = str(text_cert, 'utf-8')
+            cert = X509()
+            cert.parse(text_cert)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+
+    if args:
+        run_only = set(args)
+    else:
+        run_only = None
+
+    conversations = {}
+
+    # sanity check for Client Certificates
+    conversation = Connect(hostname, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = \
+        ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = \
+        SupportedVersionsExtension().create([(3, 4), (3, 3)])
+    ext[ExtensionType.supported_groups] = \
+        SupportedGroupsExtension().create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificateRequest())
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(CertificateGenerator())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+    bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                       AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+    conversations["sanity"] = conversation
+
+    if cert and private_key:
+        # sanity check for Client Certificates
+        conversation = Connect(hostname, port)
+        node = conversation
+        ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+        ext = {}
+        groups = [GroupName.secp256r1]
+        key_shares = []
+        for group in groups:
+            key_shares.append(key_share_gen(group))
+        ext[ExtensionType.key_share] = \
+            ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = \
+            SupportedVersionsExtension().create([(3, 4), (3, 3)])
+        ext[ExtensionType.supported_groups] = \
+            SupportedGroupsExtension().create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256]
+        ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
+        node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+        node = node.add_child(ExpectServerHello())
+        node = node.add_child(ExpectChangeCipherSpec())
+        node = node.add_child(ExpectEncryptedExtensions())
+        node = node.add_child(ExpectCertificateRequest())
+        node = node.add_child(ExpectCertificate())
+        node = node.add_child(ExpectCertificateVerify())
+        node = node.add_child(ExpectFinished())
+        node = node.add_child(CertificateGenerator(X509CertChain([cert])))
+        node = node.add_child(CertificateVerifyGenerator(private_key))
+        node = node.add_child(FinishedGenerator())
+        node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+        # This message is optional and may show up 0 to many times
+        cycle = ExpectNewSessionTicket()
+        node = node.add_child(cycle)
+        node.add_child(cycle)
+
+        node.next_sibling = ExpectApplicationData()
+        node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                           AlertDescription.close_notify))
+
+        node = node.add_child(ExpectAlert())
+        node.next_sibling = ExpectClose()
+        conversations["with certificate"] = conversation
+
+    # verify the advertised hashes
+    conversation = Connect(hostname, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = \
+        ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = \
+        SupportedVersionsExtension().create([(3, 4), (3, 3)])
+    ext[ExtensionType.supported_groups] = \
+        SupportedGroupsExtension().create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificateRequest(sigalgs))
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(CertificateGenerator())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+    bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                       AlertDescription.close_notify))
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+
+    conversations["check sigalgs in cert request"] = conversation
+
+    # run the conversation
+    good = 0
+    bad = 0
+    failed = []
+
+    # make sure that sanity test is run first and last
+    # to verify that server was running and kept running throught
+    sanity_test = ('sanity', conversations['sanity'])
+    ordered_tests = chain([sanity_test],
+                          filter(lambda x: x[0] != 'sanity',
+                                 conversations.items()),
+                          [sanity_test])
+
+    for c_name, c_test in ordered_tests:
+        if run_only and c_name not in run_only or c_name in run_exclude:
+            continue
+        print("{0} ...".format(c_name))
+
+        runner = Runner(c_test)
+
+        res = True
+        try:
+            runner.run()
+        except:
+            print("Error while processing")
+            print(traceback.format_exc())
+            res = False
+
+        if res:
+            good += 1
+            print("OK\n")
+        else:
+            bad += 1
+            failed.append(c_name)
+
+    print("Test to verify if server accepts empty certificate messages and")
+    print("advertises only expected signature algotithms in Certificate")
+    print("Request message\n")
+    print("version: {0}\n".format(version))
+
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+    failed_sorted = sorted(failed, key=natural_sort_keys)
+    print("  {0}".format('\n  '.join(repr(i) for i in failed_sorted)))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tlsfuzzer_messages.py
+++ b/tests/test_tlsfuzzer_messages.py
@@ -1041,8 +1041,9 @@ class TestCertificateGenerator(unittest.TestCase):
 
     def test_generate(self):
         certg = CertificateGenerator()
+        state = ConnectionState()
 
-        msg = certg.generate(None)
+        msg = certg.generate(state)
 
         self.assertIsInstance(msg, messages.Certificate)
         self.assertIsNone(msg.certChain)

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -318,6 +318,10 @@
          {"name" : "test-rsa-sigs-on-certificate-verify.py",
           "arguments" : ["-k", "tests/clientX509Key.pem",
                          "-c", "tests/clientX509Cert.pem"]
+          },
+         {"name" : "test-tls13-certificate-request.py",
+          "arguments" : ["-k", "tests/clientX509Key.pem",
+                         "-c", "tests/clientX509Cert.pem"]
           }
      ]
     },

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -296,6 +296,10 @@
          {"name" : "test-rsa-sigs-on-certificate-verify.py",
           "arguments" : ["-k", "tests/clientX509Key.pem",
                          "-c", "tests/clientX509Cert.pem"]
+          },
+         {"name" : "test-tls13-certificate-request.py",
+          "arguments" : ["-k", "tests/clientX509Key.pem",
+                         "-c", "tests/clientX509Cert.pem"]
           }
      ]
     },


### PR DESCRIPTION
Tests new TLS 1.3 client certificate support in tlslite-ng

### Description
Adds support for sending and receiving Client Certificates in TLS 1.3

### Motivation and Context
Fixes #198 

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/491)
<!-- Reviewable:end -->
