### PR TITLE
Do not allow pkcs1 sig algs with TLS 1.3 protocol

### DIFF
--- a/tests/test_tlsfuzzer_messages.py
+++ b/tests/test_tlsfuzzer_messages.py
@@ -1109,6 +1109,28 @@ class TestCertificateVerifyGenerator(unittest.TestCase):
                          (constants.HashAlgorithm.sha256,
                           constants.SignatureAlgorithm.rsa))
 
+    def test_generate_TLS_1_3_with_cert_request(self):
+        priv_key = generateRSAKey(1024)
+        cert_ver_g = CertificateVerifyGenerator(priv_key)
+        state = ConnectionState()
+        state.version = (3, 4)
+        req = CertificateRequest((3, 4)).create([], [],
+            [(constants.HashAlgorithm.md5, constants.SignatureAlgorithm.rsa),
+             constants.SignatureScheme.rsa_pkcs1_sha1,
+             constants.SignatureScheme.rsa_pkcs1_sha224,
+             constants.SignatureScheme.rsa_pkcs1_sha256,
+             constants.SignatureScheme.rsa_pkcs1_sha384,
+             constants.SignatureScheme.rsa_pkcs1_sha512,
+             constants.SignatureScheme.rsa_pss_rsae_sha256])
+        state.handshake_messages = [req]
+
+        msg = cert_ver_g.generate(state)
+
+        self.assertIsNotNone(msg)
+        self.assertEqual(len(msg.signature), 128)
+        self.assertEqual(msg.signatureAlgorithm,
+                         constants.SignatureScheme.rsa_pss_rsae_sha256)
+
     def test_generate_with_mismatched_alg(self):
         priv_key = generateRSAKey(1024)
         cert_ver_g = CertificateVerifyGenerator(priv_key,


### PR DESCRIPTION
When tls1.3 is used pkcs1 is not supported so prevent selecting
rsa_pkcs1_shaXXX singature algorithms if TLS1.3 is in use.

Move signature algorithm selection to a helper function to make it
easier to read.

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [x] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/495)
<!-- Reviewable:end -->
