### PR TITLE
fix tests to accept the default of 2 tickets from tlslite-ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You'll need:
 
  * Python 2.6 or later or Python 3.2 or later
  * [tlslite-ng](https://github.com/tomato42/tlslite-ng)
-   0.8.0-alpha25 or later (note that `tlslite` will *not* work and
+   0.8.0-alpha26 or later (note that `tlslite` will *not* work and
    they conflict with each other)
  * [ecdsa](https://github.com/warner/python-ecdsa)
    python module (dependency of tlslite-ng, should get installed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tlslite-ng>=0.8.0-alpha25
+tlslite-ng>=0.8.0-alpha26

--- a/scripts/test-tls13-pkcs-signature.py
+++ b/scripts/test-tls13-pkcs-signature.py
@@ -102,10 +102,16 @@ def main():
     node = node.add_child(FinishedGenerator())
     node = node.add_child(ApplicationDataGenerator(
         bytearray(b"GET / HTTP/1.0\r\n\r\n")))
-    node = node.add_child(ExpectNewSessionTicket())
-    node = node.add_child(ExpectApplicationData())
-    node = node.add_child(AlertGenerator(AlertLevel.warning,
-                                         AlertDescription.close_notify))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                       AlertDescription.close_notify))
+
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["sanity"] = conversation

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -214,7 +214,7 @@
           "exp_pass" : false},
          {"name" : "test-tls13-conversation.py"},
          {"name" : "test-tls13-count-tickets.py",
-          "arguments" : ["-t", "1"]},
+          "arguments" : ["-t", "2"]},
          {"name" : "test-tls13-crfg-curves.py"},
          {"name" : "test-tls13-dhe-shared-secret-padding.py",
           "arguments" : ["TLS 1.3 with ffdhe2048"],

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -202,7 +202,7 @@
           "exp_pass" : false},
          {"name" : "test-tls13-conversation.py"},
          {"name" : "test-tls13-count-tickets.py",
-          "arguments" : ["-t", "1"]},
+          "arguments" : ["-t", "2"]},
          {"name" : "test-tls13-crfg-curves.py"},
          {"name" : "test-tls13-dhe-shared-secret-padding.py"},
          {"name" : "test-tls13-empty-alert.py"},


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
fix tests after changes to defaults in tlslite-ng: it now sends 2 tickets, not one

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
make the tests pass again

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/498)
<!-- Reviewable:end -->
