### PR TITLE
shift unknown groups boundary to follow IANA assignment

### DIFF
--- a/scripts/test-tls13-unrecognised-groups.py
+++ b/scripts/test-tls13-unrecognised-groups.py
@@ -126,7 +126,7 @@ def main():
     conversations["sanity"] = conversation
 
     unknown_groups = {
-        'EC': list(range(31, 255)),  # Unassigned groups from EC range
+        'EC': list(range(34, 255)),  # Unassigned groups from EC range
         'FFDHE': list(range(261, 507)),  # Unassigned groups from FFDHE range
     }
     known_groups = [GroupName.secp256r1, GroupName.ffdhe2048]


### PR DESCRIPTION
### Description
Update unknown_groups to account for IANA assignment.

### Motivation and Context
IANA has assigned several groups from EC range list to brainpool and gost
curves. Update unknown_groups accordingly. This becomes necessary for
GnuTLS testsuite to pass

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [x] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/513)
<!-- Reviewable:end -->
