### PR TITLE
differentiate close from timeout for ExpectClose()

### DIFF
--- a/scripts/test-cve-2016-6309.py
+++ b/scripts/test-cve-2016-6309.py
@@ -14,10 +14,10 @@ from tlsfuzzer.runner import Runner
 from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
         ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
         FinishedGenerator, AlertGenerator, fuzz_message, \
-        ApplicationDataGenerator
+        ApplicationDataGenerator, Close
 from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
         ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
-        ExpectAlert, ExpectClose, ExpectApplicationData
+        ExpectAlert, ExpectClose, ExpectApplicationData, ExpectNoMessage
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
         ExtensionType
 from tlslite.extensions import PaddingExtension
@@ -116,14 +116,16 @@ def main():
     conversations["Large ClientHello padding"] = conversation
 
     # change ClientHello length to incorrect large length
-    conversation = Connect(host, port)
+    conversation = Connect(host, port, timeout=5)
     node = conversation
     ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
     # lowest size substitution, that causes OpenSSL 1.1.0 and 1.1.0a
     # to crash (SIGABRT)
     node = node.add_child(fuzz_message(ClientHelloGenerator(ciphers),
                                        substitutions={2:0x55, 3:0x55}))
-    node = node.add_child(ExpectClose())
+    # wait for the timeout set in Connect to occur
+    node = node.add_child(ExpectNoMessage(timeout=6))
+    node.add_child(Close())
 
     conversations["Large incorrect ClientHello length"] = conversation
 

--- a/tlsfuzzer/runner.py
+++ b/tlsfuzzer/runner.py
@@ -194,7 +194,11 @@ class Runner(object):
                         close_node = next((n for n in node.get_all_siblings()
                                            if isinstance(n, ExpectClose)),
                                           None)
-                        if close_node:
+                        # timeout will happen if the other side hanged, to
+                        # try differentiated between (when no alerts are sent)
+                        # allow for close only when the connection was actively
+                        # closed
+                        if close_node and not isinstance(exc, socket.timeout):
                             close_node.process(self.state, None)
                             node = close_node.child
                             continue


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
differentiate timeout from close for ExpectClose()

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
when server hangs because of the invalid/malformed messages we sent, further communication will timeout, we won't receive a close right away - allow for differentiating those two situations

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/517)
<!-- Reviewable:end -->
