### PR TITLE
ECDSA test

### DIFF
--- a/scripts/test-certificate-request.py
+++ b/scripts/test-certificate-request.py
@@ -58,7 +58,12 @@ def main():
     cert = None
     private_key = None
 
-    sigalgs = [SignatureScheme.rsa_pss_rsae_sha512,
+    sigalgs = [SignatureScheme.ecdsa_secp521r1_sha512,
+               SignatureScheme.ecdsa_secp384r1_sha384,
+               SignatureScheme.ecdsa_secp256r1_sha256,
+               (HashAlgorithm.sha224, SignatureAlgorithm.ecdsa),
+               (HashAlgorithm.sha1, SignatureAlgorithm.ecdsa),
+               SignatureScheme.rsa_pss_rsae_sha512,
                SignatureScheme.rsa_pss_pss_sha512,
                SignatureScheme.rsa_pss_rsae_sha384,
                SignatureScheme.rsa_pss_pss_sha384,

--- a/scripts/test-certificate-verify-malformed.py
+++ b/scripts/test-certificate-verify-malformed.py
@@ -216,7 +216,7 @@ def main():
         node = node.add_child(CertificateGenerator(X509CertChain([cert])))
         node = node.add_child(ClientKeyExchangeGenerator())
         node = node.add_child(TCPBufferingFlush())
-        node = node.add_child(CertificateVerifyGenerator(signature=sig[:i]))
+        node = node.add_child(CertificateVerifyGenerator(private_key, signature=sig[:i]))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(TCPBufferingDisable())

--- a/scripts/test-rsa-pss-sigs-on-certificate-verify.py
+++ b/scripts/test-rsa-pss-sigs-on-certificate-verify.py
@@ -70,7 +70,12 @@ def main():
     cert = None
     exp_illeg_param = False
 
-    sigalgs = [SignatureScheme.rsa_pss_rsae_sha512,
+    sigalgs = [SignatureScheme.ecdsa_secp521r1_sha512,
+               SignatureScheme.ecdsa_secp384r1_sha384,
+               SignatureScheme.ecdsa_secp256r1_sha256,
+               (HashAlgorithm.sha224, SignatureAlgorithm.ecdsa),
+               (HashAlgorithm.sha1, SignatureAlgorithm.ecdsa),
+               SignatureScheme.rsa_pss_rsae_sha512,
                SignatureScheme.rsa_pss_pss_sha512,
                SignatureScheme.rsa_pss_rsae_sha384,
                SignatureScheme.rsa_pss_pss_sha384,

--- a/scripts/test-tls13-certificate-request.py
+++ b/scripts/test-tls13-certificate-request.py
@@ -60,7 +60,12 @@ def main():
     cert = None
     private_key = None
 
-    sigalgs = [SignatureScheme.rsa_pss_rsae_sha512,
+    sigalgs = [SignatureScheme.ecdsa_secp521r1_sha512,
+               SignatureScheme.ecdsa_secp384r1_sha384,
+               SignatureScheme.ecdsa_secp256r1_sha256,
+               (HashAlgorithm.sha224, SignatureAlgorithm.ecdsa),
+               (HashAlgorithm.sha1, SignatureAlgorithm.ecdsa),
+               SignatureScheme.rsa_pss_rsae_sha512,
                SignatureScheme.rsa_pss_pss_sha512,
                SignatureScheme.rsa_pss_rsae_sha384,
                SignatureScheme.rsa_pss_pss_sha384,

--- a/scripts/test-tls13-certificate-verify.py
+++ b/scripts/test-tls13-certificate-verify.py
@@ -118,7 +118,12 @@ def main():
     private_key = None
 
     # algorithms to expect from server in Certificate Request
-    cr_sigalgs = [SignatureScheme.rsa_pss_rsae_sha512,
+    cr_sigalgs = [SignatureScheme.ecdsa_secp521r1_sha512,
+                  SignatureScheme.ecdsa_secp384r1_sha384,
+                  SignatureScheme.ecdsa_secp256r1_sha256,
+                  (HashAlgorithm.sha224, SignatureAlgorithm.ecdsa),
+                  (HashAlgorithm.sha1, SignatureAlgorithm.ecdsa),
+                  SignatureScheme.rsa_pss_rsae_sha512,
                   SignatureScheme.rsa_pss_pss_sha512,
                   SignatureScheme.rsa_pss_rsae_sha384,
                   SignatureScheme.rsa_pss_pss_sha384,

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -913,6 +913,7 @@ class CertificateVerifyGenerator(HandshakeProtocolMessageGenerator):
                 if not self.private_key:
                     # when sending malformed messages, the key may not be
                     # even loaded, so select any algorithm acceptable to server
+                    # TODO: check if it matches the certificate we sent!
                     self.msg_alg = cert_req.supported_signature_algs[0]
                 else:
                     self.msg_alg = self._select_sig_alg(cert_req)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
update tests to support tlslite-ng with ECDSA support

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
ECDSA is the the new signature algorithm we need to support for better and more complete test coverage of all TLS versions

depends on https://github.com/tomato42/tlslite-ng/pull/196

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md
