### PR TITLE
TLSv1_2-rejected-without-TLSv1_2: stricter check

### DIFF
--- a/scripts/test-TLSv1_2-rejected-without-TLSv1_2.py
+++ b/scripts/test-TLSv1_2-rejected-without-TLSv1_2.py
@@ -126,17 +126,10 @@ def main():
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
 
-    conversations["sanity"] = conversation
+    conversations["sanity - TLS 1.1 enabled"] = conversation
 
     # check TLSv1.2 ciphers without TLSv1.2 client hello
-    for cipher in [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
-                   CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
-                   CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
-                   CipherSuite.TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
-                   CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
-                   CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256,
-                   CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
-                   CipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384]:
+    for cipher in CipherSuite.tls12Suites:
         conversation = Connect(host, port)
         node = conversation
         ciphers = [cipher]

--- a/scripts/test-TLSv1_2-rejected-without-TLSv1_2.py
+++ b/scripts/test-TLSv1_2-rejected-without-TLSv1_2.py
@@ -23,6 +23,9 @@ from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
 from tlsfuzzer.utils.lists import natural_sort_keys
 
 
+version = 2
+
+
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
     print(" -h hostname    name of the host to run the test against")
@@ -33,7 +36,7 @@ def help_msg():
     print(" -e probe-name  exclude the probe from the list of the ones run")
     print("                may be specified multiple times")
     print(" -n num         only run `num` random tests instead of a full set")
-    print("                (excluding \"sanity\" tests)")
+    print("                (\"sanity\" tests are always executed)")
     print(" --help         this message")
 
 
@@ -76,6 +79,35 @@ def main():
                                                extensions={ExtensionType.
                                                    renegotiation_info:None}))
     node = node.add_child(ExpectServerHello(version=(3, 3),
+                                            extensions={ExtensionType.
+                                                     renegotiation_info:None}))
+    node = node.add_child(ExpectCertificate())
+    #node = node.add_child(ExpectServerKeyExchange())
+    node = node.add_child(ExpectServerHelloDone())
+    node = node.add_child(ClientKeyExchangeGenerator())
+    node = node.add_child(ChangeCipherSpecGenerator())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\n\n")))
+    node = node.add_child(ExpectApplicationData())
+    node = node.add_child(AlertGenerator(AlertLevel.warning,
+                                         AlertDescription.close_notify))
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+
+    conversations["sanity"] = conversation
+
+    # sanity check - TLS 1.1 enabled
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA]
+    node = node.add_child(ClientHelloGenerator(ciphers,
+                                               version=(3, 2),
+                                               extensions={ExtensionType.
+                                                   renegotiation_info:None}))
+    node = node.add_child(ExpectServerHello(version=(3, 2),
                                             extensions={ExtensionType.
                                                      renegotiation_info:None}))
     node = node.add_child(ExpectCertificate())
@@ -144,7 +176,7 @@ def main():
         res = True
         try:
             runner.run()
-        except:
+        except Exception:
             print("Error while processing")
             print(traceback.format_exc())
             res = False
@@ -155,6 +187,10 @@ def main():
         else:
             bad += 1
             failed.append(c_name)
+
+    print("Script to verify that server does not negotiate TLS1.2 ciphers")
+    print("in TLS1.1 or earlier protocol")
+    print("version: {0}\n".format(version))
 
     print("Test end")
     print("successful: {0}".format(good))

--- a/scripts/test-TLSv1_2-rejected-without-TLSv1_2.py
+++ b/scripts/test-TLSv1_2-rejected-without-TLSv1_2.py
@@ -112,8 +112,9 @@ def main():
                                                    version=(3, 2),
                                                    extensions={ExtensionType.
                                                        renegotiation_info:None}))
-        node = node.add_child(ExpectAlert())
-        node.next_sibling = ExpectClose()
+        node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                          AlertDescription.handshake_failure))
+        node.add_child(ExpectClose())
 
         conversations[CipherSuite.ietfNames[cipher] + " in TLSv1.1"] =\
                 conversation


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
* make the script checks more strict
* test more ciphers
* make script more user-friendly (make ^C actually kill it)

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
better test coverage for TLS 1.1 and TLS 1.2 servers

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [x] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/548)
<!-- Reviewable:end -->
