### PR TITLE
test-ffdhe-negotiation: Allow setting expected alert when no overlap

### DIFF
--- a/scripts/test-ffdhe-negotiation.py
+++ b/scripts/test-ffdhe-negotiation.py
@@ -28,6 +28,10 @@ def help_msg():
     print(" -h hostname    name of the host to run the test against")
     print("                localhost by default")
     print(" -p port        port number to use for connection, 4433 by default")
+    print(" --alert name   the expected alert description when no overlap")
+    print("                between groups - insufficient_security by default")
+    print("                as per RFC 7919, while there is an erratum removing")
+    print("                this restriction")
     print(" probe-name     if present, will run only the probes with given")
     print("                names and not all of them, e.g \"sanity\"")
     print(" -e probe-name  exclude the probe from the list of the ones run")
@@ -42,10 +46,11 @@ def main():
     host = "localhost"
     port = 4433
     num_limit = None
+    fatal_alert = "insufficient_security"
     run_exclude = set()
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:n:", ["help"])
+    opts, args = getopt.getopt(argv, "h:p:e:n:", ["help", "alert="])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -55,6 +60,8 @@ def main():
             run_exclude.add(arg)
         elif opt == '-n':
             num_limit = int(arg)
+        elif opt == '--alert':
+            fatal_alert = arg
         elif opt == '--help':
             help_msg()
             sys.exit(0)
@@ -329,7 +336,7 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                extensions=ext))
     node = node.add_child(ExpectAlert(AlertLevel.fatal,
-                                      AlertDescription.insufficient_security))
+                                      getattr(AlertDescription, fatal_alert)))
     node.add_child(ExpectClose())
 
     conversations["no overlap between groups"] = conversation


### PR DESCRIPTION
The restriction of alert description being insufficient_security was
removed in the erratum:
https://www.rfc-editor.org/errata_search.php?rfc=7919

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
https://gitlab.com/gnutls/gnutls/merge_requests/987

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [x] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/549)
<!-- Reviewable:end -->
