### PR TITLE
Post handshake auth

### DIFF
--- a/3rd-party-scripts/README.md
+++ b/3rd-party-scripts/README.md
@@ -1,0 +1,1 @@
+Scripts and tools to make testing servers other than tlslite-ng easier.

--- a/3rd-party-scripts/openssl-server-pha.expect
+++ b/3rd-party-scripts/openssl-server-pha.expect
@@ -1,0 +1,44 @@
+#!/usr/bin/expect
+# execute like this:
+# openssl-server-pha.expect openssl s_server -key /tmp/server/key.pem -cert /tmp/server/cert.pem -CAfile /tmp/ca/cert.pem
+set timeout 30
+set exp_internal 1
+eval spawn $argv
+trap { exec kill -SIGTERM [exp_pid] } SIGTERM
+expect {
+    "CIPHER is" {
+        expect {
+            "GET / HTTP/1.0" { send "HTTP/1.0 200 ok\r"; }
+            "GET /secret HTTP/1.0" {
+                send "c\r";
+                send_user "== expect: waiting for client cert\n";
+                set timeout 1;
+                expect {
+                    "verify return:1" {
+                        expect {
+                            "Read BLOCK" { send "HTTP/1.0 200 ok\r"; }
+                            "error" { }
+                            "ERROR" { }
+                            eof { exit 15 }
+                            timeout { exit 16 }
+                        }
+                    } timeout {
+                        send_user "== expect: no certificate received\n";
+                        send "HTTP/1.0 401 authentication required\r";
+                    }
+                    "ERROR" { }
+                    eof { exit 13 }
+                }
+                send_user "== expect: client cert handled\n";
+                set timeout 10;
+            }
+            eof { exit 11 }
+            timeout { exit 12 }
+        }
+        exp_continue;
+    }
+    eof { exit 7 }
+    timeout { close; exit 8 }
+}
+set info [wait]
+exit [lindex $info 3]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tlslite-ng>=0.8.0-alpha33
+tlslite-ng>=0.8.0-alpha34

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tlslite-ng>=0.8.0-alpha31
+tlslite-ng>=0.8.0-alpha33

--- a/scripts/test-tls13-post-handshake-auth.py
+++ b/scripts/test-tls13-post-handshake-auth.py
@@ -54,6 +54,9 @@ def help_msg():
     print("                and reply with certificate_required")
     print(" --min-tickets n Require the server to provide at least 'n' tickets")
     print("                before performing PHA. Defaults to 0.")
+    print(" --query txt    Message to send to server to cause it to request")
+    print("                post-handshake authentication.")
+    print("                \"GET /secret HTTP/1.0\\r\\n\\r\\n\" by default")
     print(" --help         this message")
 
 
@@ -65,11 +68,12 @@ def main():
     pha_as_reply = False
     cert_required = False
     min_tickets = 0
+    pha_query = b'GET /secret HTTP/1.0\r\n\r\n'
 
     argv = sys.argv[1:]
     opts, args = getopt.getopt(
         argv, "h:p:e:n:k:c:",
-        ["help", "pha-as-reply", "cert-required", "min-tickets="])
+        ["help", "pha-as-reply", "cert-required", "min-tickets=", "query="])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -86,6 +90,8 @@ def main():
             pha_as_reply = True
         elif opt == '--cert-required':
             cert_required = True
+        elif opt == '--query':
+            pha_query = arg
         elif opt == '--min-tickets':
             min_tickets = int(arg)
         elif opt == '-k':
@@ -188,7 +194,7 @@ def main():
     node = node.add_child(FinishedGenerator())
     if pha_as_reply:
         node = node.add_child(ApplicationDataGenerator(
-            bytearray(b"GET /secret HTTP/1.0\r\n\r\n")))
+            bytearray(pha_query)))
 
     for _ in range(min_tickets):
         node = node.add_child(ExpectNewSessionTicket(note="counted"))
@@ -205,7 +211,7 @@ def main():
     node = node.add_child(FinishedGenerator(context=context))
     if not pha_as_reply:
         node = node.add_child(ApplicationDataGenerator(
-            bytearray(b"GET /secret HTTP/1.0\r\n\r\n")))
+            bytearray(pha_query)))
 
     # just like after the first handshake, after PHA, the NST can be sent
     # multiple times
@@ -253,7 +259,7 @@ def main():
     node = node.add_child(FinishedGenerator())
     if pha_as_reply:
         node = node.add_child(ApplicationDataGenerator(
-            bytearray(b"GET /secret HTTP/1.0\r\n\r\n")))
+            bytearray(pha_query)))
 
     for _ in range(min_tickets):
         node = node.add_child(ExpectNewSessionTicket(note="counted"))
@@ -272,7 +278,7 @@ def main():
     node = node.add_child(FinishedGenerator(context=context))
     if not pha_as_reply:
         node = node.add_child(ApplicationDataGenerator(
-            bytearray(b"GET /secret HTTP/1.0\r\n\r\n")))
+            bytearray(pha_query)))
 
     # just like after the first handshake, after PHA, the NST can be sent
     # multiple times
@@ -322,7 +328,7 @@ def main():
     node = node.add_child(FinishedGenerator())
     if pha_as_reply:
         node = node.add_child(ApplicationDataGenerator(
-            bytearray(b"GET /secret HTTP/1.0\r\n\r\n")))
+            bytearray(pha_query)))
 
     for _ in range(min_tickets):
         node = node.add_child(ExpectNewSessionTicket(note="counted"))
@@ -338,7 +344,7 @@ def main():
     node = node.add_child(FinishedGenerator(context=context))
     if not pha_as_reply:
         node = node.add_child(ApplicationDataGenerator(
-            bytearray(b"GET /secret HTTP/1.0\r\n\r\n")))
+            bytearray(pha_query)))
 
     if cert_required:
         node = node.add_child(ExpectAlert(
@@ -392,7 +398,7 @@ def main():
     node = node.add_child(FinishedGenerator())
     if pha_as_reply:
         node = node.add_child(ApplicationDataGenerator(
-            bytearray(b"GET /secret HTTP/1.0\r\n\r\n")))
+            bytearray(pha_query)))
 
     for _ in range(min_tickets):
         node = node.add_child(ExpectNewSessionTicket(note="counted"))

--- a/scripts/test-tls13-post-handshake-auth.py
+++ b/scripts/test-tls13-post-handshake-auth.py
@@ -1,0 +1,295 @@
+# Author: Hubert Kario, (c) 2018
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+from itertools import chain, islice
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator, \
+        CertificateVerifyGenerator, CertificateGenerator
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+        ExpectAlert, ExpectApplicationData, ExpectClose, \
+        ExpectEncryptedExtensions, ExpectCertificateVerify, \
+        ExpectNewSessionTicket, ExpectCertificateRequest
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+from tlslite.keyexchange import ECDHKeyExchange
+from tlsfuzzer.utils.lists import natural_sort_keys
+from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
+        SupportedVersionsExtension, SupportedGroupsExtension, \
+        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL, AutoEmptyExtension
+from tlslite.x509certchain import X509CertChain
+from tlslite.x509 import X509
+from tlslite.utils.keyfactory import parsePEMKey
+
+
+version = 1
+
+
+def help_msg():
+    print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
+    print(" -h hostname    name of the host to run the test against")
+    print("                localhost by default")
+    print(" -p port        port number to use for connection, 4433 by default")
+    print(" probe-name     if present, will run only the probes with given")
+    print("                names and not all of them, e.g \"sanity\"")
+    print(" -e probe-name  exclude the probe from the list of the ones run")
+    print("                may be specified multiple times")
+    print(" -n num         only run `num` random tests instead of a full set")
+    print("                (\"sanity\" tests are always executed)")
+    print(" -k keyfile     file with private key")
+    print(" -c certfile    file with certificate of client")
+    print(" --help         this message")
+
+
+def main():
+    host = "localhost"
+    port = 4433
+    num_limit = None
+    run_exclude = set()
+
+    argv = sys.argv[1:]
+    opts, args = getopt.getopt(argv, "h:p:e:n:k:c:", ["help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '-e':
+            run_exclude.add(arg)
+        elif opt == '-n':
+            num_limit = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        elif opt == '-k':
+            text_key = open(arg, 'rb').read()
+            if sys.version_info[0] >= 3:
+                text_key = str(text_key, 'utf-8')
+            private_key = parsePEMKey(text_key, private=True)
+        elif opt == '-c':
+            text_cert = open(arg, 'rb').read()
+            if sys.version_info[0] >= 3:
+                text_cert = str(text_cert, 'utf-8')
+            cert = X509()
+            cert.parse(text_cert)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+
+    if args:
+        run_only = set(args)
+    else:
+        run_only = None
+
+    conversations = {}
+
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        .create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        .create(RSA_SIG_ALL)
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                       AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+    conversations["sanity"] = conversation
+
+    # test post-handshake authentication
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        .create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        .create(RSA_SIG_ALL)
+    ext[ExtensionType.post_handshake_auth] = AutoEmptyExtension()
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(FinishedGenerator())
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    context = []
+    node.next_sibling = ExpectCertificateRequest(context=context)
+    node = node.next_sibling.add_child(CertificateGenerator(X509CertChain([cert]), context=context))
+    node = node.add_child(CertificateVerifyGenerator(private_key, context=context))
+    node = node.add_child(FinishedGenerator(context=context))
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+    # just like after the first handshake, after PHA, the NST can be sent
+    # multiple times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                       AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+    conversations["post-handshake authentication"] = conversation
+
+    # malformed signatures in post-handshake authentication
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        .create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        .create(RSA_SIG_ALL)
+    ext[ExtensionType.post_handshake_auth] = AutoEmptyExtension()
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(FinishedGenerator())
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    context = []
+    node.next_sibling = ExpectCertificateRequest(context=context)
+    node = node.next_sibling.add_child(CertificateGenerator(X509CertChain([cert]), context=context))
+    node = node.add_child(CertificateVerifyGenerator(private_key, padding_xors={-1: 0xff}, context=context))
+    node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                      AlertDescription.decrypt_error))
+    node.add_child(ExpectClose())
+    #node = node.add_child(FinishedGenerator(context=context))
+    conversations["malformed signature in PHA"] = conversation
+
+
+    # run the conversation
+    good = 0
+    bad = 0
+    failed = []
+    if not num_limit:
+        num_limit = len(conversations)
+
+    # make sure that sanity test is run first and last
+    # to verify that server was running and kept running throught
+    sanity_test = ('sanity', conversations['sanity'])
+    ordered_tests = chain([sanity_test],
+                          islice(filter(lambda x: x[0] != 'sanity',
+                                        conversations.items()), num_limit),
+                          [sanity_test])
+
+    for c_name, c_test in ordered_tests:
+        if run_only and c_name not in run_only or c_name in run_exclude:
+            continue
+        print("{0} ...".format(c_name))
+
+        runner = Runner(c_test)
+
+        res = True
+        try:
+            runner.run()
+        except Exception:
+            print("Error while processing")
+            print(traceback.format_exc())
+            res = False
+
+        if res:
+            good += 1
+            print("OK\n")
+        else:
+            bad += 1
+            failed.append(c_name)
+
+    print("Basic post-handshake authentication test case")
+    print("Check if server will accept PHA, check if server rejects invalid")
+    print("signatures on PHA CertificateVerify")
+    print("version: {0}\n".format(version))
+
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+    failed_sorted = sorted(failed, key=natural_sort_keys)
+    print("  {0}".format('\n  '.join(repr(i) for i in failed_sorted)))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-tls13-post-handshake-auth.py
+++ b/scripts/test-tls13-post-handshake-auth.py
@@ -300,9 +300,18 @@ def main():
 
     node.next_sibling = ExpectKeyUpdate(
         KeyUpdateMessageType.update_not_requested)
-    node = node.next_sibling.add_child(ExpectApplicationData())
-    node = node.add_child(AlertGenerator(AlertLevel.warning,
-                                         AlertDescription.close_notify))
+
+    # but KeyUpdate can be sent asynchonously, then NST will be received
+    # after KeyUpdate
+
+    cycle = ExpectNewSessionTicket(note="third set")
+    node = node.next_sibling.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(
+        AlertGenerator(AlertLevel.warning,
+                       AlertDescription.close_notify))
 
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()

--- a/scripts/test-tls13-post-handshake-auth.py
+++ b/scripts/test-tls13-post-handshake-auth.py
@@ -49,6 +49,8 @@ def help_msg():
     print(" -c certfile    file with certificate of client")
     print(" --pha-as-reply expect post-handshake auth request as a reply to")
     print("                the HTTP GET instead of right after handshake")
+    print(" --cert-required expect the server to require a client certificate")
+    print("                and reply with certificate_required")
     print(" --help         this message")
 
 
@@ -58,9 +60,12 @@ def main():
     num_limit = None
     run_exclude = set()
     pha_as_reply = False
+    cert_required = False
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:n:k:c:", ["help", "pha-as-reply"])
+    opts, args = getopt.getopt(
+        argv, "h:p:e:n:k:c:",
+        ["help", "pha-as-reply", "cert-required"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -75,6 +80,8 @@ def main():
             sys.exit(0)
         elif opt == '--pha-as-reply':
             pha_as_reply = True
+        elif opt == '--cert-required':
+            cert_required = True
         elif opt == '-k':
             text_key = open(arg, 'rb').read()
             if sys.version_info[0] >= 3:
@@ -201,6 +208,73 @@ def main():
     node = node.add_child(ExpectAlert())
     node.next_sibling = ExpectClose()
     conversations["post-handshake authentication"] = conversation
+
+    # test post-handshake with client not providing a certificate
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        .create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        .create(RSA_SIG_ALL)
+    ext[ExtensionType.post_handshake_auth] = AutoEmptyExtension()
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(FinishedGenerator())
+    if pha_as_reply:
+        node = node.add_child(ApplicationDataGenerator(
+            bytearray(b"GET /secret HTTP/1.0\r\n\r\n")))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket(note="first set")
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    context = []
+    node.next_sibling = ExpectCertificateRequest(context=context)
+    node = node.next_sibling.add_child(CertificateGenerator(X509CertChain([]), context=context))
+    node = node.add_child(FinishedGenerator(context=context))
+    if not pha_as_reply:
+        node = node.add_child(ApplicationDataGenerator(
+            bytearray(b"GET /secret HTTP/1.0\r\n\r\n")))
+
+    if cert_required:
+        node = node.add_child(ExpectAlert(
+            AlertLevel.fatal,
+            AlertDescription.certificate_required))
+        node.add_child(ExpectClose())
+    else:
+        # just like after the first handshake, after PHA, the NST can be sent
+        # multiple times
+        cycle = ExpectNewSessionTicket(note="second set")
+        node = node.add_child(cycle)
+        node.add_child(cycle)
+
+        node.next_sibling = ExpectApplicationData()
+        node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                           AlertDescription.close_notify))
+
+        node = node.add_child(ExpectAlert())
+        node.next_sibling = ExpectClose()
+    conversations["post-handshake authentication with no client cert"] = conversation
 
     # malformed signatures in post-handshake authentication
     conversation = Connect(host, port)

--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -3539,6 +3539,22 @@ class TestExpectCertificateRequest(unittest.TestCase):
         with self.assertRaises(ValueError):
             exp.process(state, msg)
 
+    def test_process_with_context_set(self):
+        ext = SignatureAlgorithmsExtension().create(
+            [SignatureScheme.rsa_pss_rsae_sha256])
+
+        state = ConnectionState()
+        state.version = (3, 4)
+        ctx = []
+        exp = ExpectCertificateRequest(context=ctx)
+
+        msg = CertificateRequest((3, 4))
+        msg.create(extensions=[ext])
+
+        exp.process(state, msg)
+
+        self.assertEqual(ctx, [msg])
+
 
 class TestExpectHeartbeat(unittest.TestCase):
     def test___init__(self):

--- a/tests/test_tlsfuzzer_messages.py
+++ b/tests/test_tlsfuzzer_messages.py
@@ -30,7 +30,7 @@ from tlsfuzzer.messages import ClientHelloGenerator, ClientKeyExchangeGenerator,
         SetPaddingCallback, replace_plaintext, ch_cookie_handler, \
         ch_key_share_handler, SetRecordVersion, CopyVariables, \
         ResetWriteConnectionState, HeartbeatGenerator, Certificate, \
-        KeyUpdateGenerator
+        KeyUpdateGenerator, ClearContext
 from tlsfuzzer.helpers import psk_ext_gen, psk_ext_updater, \
         psk_session_ext_gen, AutoEmptyExtension
 from tlsfuzzer.runner import ConnectionState
@@ -2354,6 +2354,26 @@ class TestCertificateVerifyGeneratorECDSA(unittest.TestCase):
         self.assertTrue(priv_key.verify(
             sig, secureHash(b"", "sha1"),
             "", "sha1"))
+
+
+class TestClearContext(unittest.TestCase):
+    def test___init__(self):
+        ctx = []
+        cc = ClearContext(ctx)
+
+        self.assertIs(cc.context, ctx)
+        self.assertTrue(cc.is_command())
+        self.assertFalse(cc.is_expect())
+        self.assertFalse(cc.is_generator())
+
+    def test_process(self):
+        ctx = ["abc", 123]
+        cc = ClearContext(ctx)
+        self.assertEqual(ctx, ["abc", 123])
+
+        cc.process(None)
+
+        self.assertEqual(ctx, [])
 
 
 class TestAlertGenerator(unittest.TestCase):

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -569,6 +569,21 @@
      ]
     },
     {"server_command": ["python", "-u", "{command}", "server",
+                 "-k", "tests/serverX509Key.pem",
+                 "-c", "tests/serverX509Cert.pem",
+                 "--request-pha",
+                 "localhost:4433"],
+     "server_hostname": "localhost",
+     "server_port": 4433,
+     "environment": {"PYTHONPATH": "."},
+     "tests" : [
+         {"name" : "test-tls13-post-handshake-auth.py",
+          "arguments" : ["-k", "tests/clientX509Key.pem",
+                         "-c", "tests/clientX509Cert.pem"]
+         }
+     ]
+    },
+    {"server_command": ["python", "-u", "{command}", "server",
                 "-c", "tests/serverECCert.pem",
                 "-k", "tests/serverECKey.pem",
                 "-c", "tests/serverP384ECCert.pem",

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -600,7 +600,8 @@
          {"name" : "test-tls13-post-handshake-auth.py",
           "arguments" : ["-k", "tests/clientX509Key.pem",
                          "-c", "tests/clientX509Cert.pem",
-                         "--pha-as-reply", "--cert-required"]
+                         "--pha-as-reply", "--cert-required",
+                         "--min-tickets=2"]
          }
      ]
     },

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -360,6 +360,11 @@
          {"name" : "test-tls13-nociphers.py"},
          {"name" : "test-tls13-obsolete-curves.py"},
          {"name" : "test-tls13-pkcs-signature.py"},
+         {"name" : "test-tls13-post-handshake-auth.py",
+          "arguments" : ["-k", "tests/clientX509Key.pem",
+                         "-c", "tests/clientX509Cert.pem",
+                         "--pha-as-reply"]
+          },
          {"name" : "test-tls13-record-layer-limits.py",
           "arguments" : ["-n", "50"]},
          {"name" : "test-tls13-record-padding.py"},

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -589,6 +589,22 @@
      ]
     },
     {"server_command": ["python", "-u", "{command}", "server",
+                 "-k", "tests/serverX509Key.pem",
+                 "-c", "tests/serverX509Cert.pem",
+                 "--require-pha",
+                 "localhost:4433"],
+     "server_hostname": "localhost",
+     "server_port": 4433,
+     "environment": {"PYTHONPATH": "."},
+     "tests" : [
+         {"name" : "test-tls13-post-handshake-auth.py",
+          "arguments" : ["-k", "tests/clientX509Key.pem",
+                         "-c", "tests/clientX509Cert.pem",
+                         "--pha-as-reply", "--cert-required"]
+         }
+     ]
+    },
+    {"server_command": ["python", "-u", "{command}", "server",
                 "-c", "tests/serverECCert.pem",
                 "-k", "tests/serverECKey.pem",
                 "-c", "tests/serverP384ECCert.pem",

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -339,6 +339,11 @@
          {"name" : "test-tls13-nociphers.py"},
          {"name" : "test-tls13-obsolete-curves.py"},
          {"name" : "test-tls13-pkcs-signature.py"},
+         {"name" : "test-tls13-post-handshake-auth.py",
+          "arguments" : ["-k", "tests/clientX509Key.pem",
+                         "-c", "tests/clientX509Cert.pem",
+                         "--pha-as-reply"]
+          },
          {"name" : "test-tls13-record-layer-limits.py"},
          {"name" : "test-tls13-record-padding.py"},
          {"name" : "test-tls13-rsa-signatures.py"},

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -537,6 +537,21 @@
      ]
     },
     {"server_command": ["python", "-u", "{command}", "server",
+                 "-k", "tests/serverX509Key.pem",
+                 "-c", "tests/serverX509Cert.pem",
+                 "--request-pha",
+                 "localhost:4433"],
+     "server_hostname": "localhost",
+     "server_port": 4433,
+     "environment": {"PYTHONPATH": "."},
+     "tests" : [
+         {"name" : "test-tls13-post-handshake-auth.py",
+          "arguments" : ["-k", "tests/clientX509Key.pem",
+                         "-c", "tests/clientX509Cert.pem"]
+         }
+     ]
+    },
+    {"server_command": ["python", "-u", "{command}", "server",
                 "-k", "tests/serverECKey.pem",
                 "-c", "tests/serverECCert.pem",
                 "--cipherlist", "chacha20-poly1305",

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -568,7 +568,8 @@
          {"name" : "test-tls13-post-handshake-auth.py",
           "arguments" : ["-k", "tests/clientX509Key.pem",
                          "-c", "tests/clientX509Cert.pem",
-                         "--pha-as-reply", "--cert-required"]
+                         "--pha-as-reply", "--cert-required",
+                         "--min-tickets=2"]
          }
      ]
     },

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -557,6 +557,22 @@
      ]
     },
     {"server_command": ["python", "-u", "{command}", "server",
+                 "-k", "tests/serverX509Key.pem",
+                 "-c", "tests/serverX509Cert.pem",
+                 "--require-pha",
+                 "localhost:4433"],
+     "server_hostname": "localhost",
+     "server_port": 4433,
+     "environment": {"PYTHONPATH": "."},
+     "tests" : [
+         {"name" : "test-tls13-post-handshake-auth.py",
+          "arguments" : ["-k", "tests/clientX509Key.pem",
+                         "-c", "tests/clientX509Cert.pem",
+                         "--pha-as-reply", "--cert-required"]
+         }
+     ]
+    },
+    {"server_command": ["python", "-u", "{command}", "server",
                 "-k", "tests/serverECKey.pem",
                 "-c", "tests/serverECCert.pem",
                 "--cipherlist", "chacha20-poly1305",

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -1171,7 +1171,7 @@ class ExpectCertificateRequest(_ExpectExtensionsMessage):
     """Processing TLS Handshake protocol Certificate Request message."""
 
     def __init__(self, sig_algs=None, cert_types=None,
-                 sanity_check_cert_types=True, extensions=None):
+                 sanity_check_cert_types=True, extensions=None, context=None):
         """
         Set expected parameters for the CertificateRequest message.
 
@@ -1196,6 +1196,7 @@ class ExpectCertificateRequest(_ExpectExtensionsMessage):
                                                        extensions)
         self.sig_algs = sig_algs
         self.cert_types = cert_types
+        self.context = context
         self.sanity_check_cert_types = sanity_check_cert_types
         if sig_algs is not None and extensions is not None:
             raise ValueError("Can't set sig_algs and extensions at the same "
@@ -1301,6 +1302,8 @@ class ExpectCertificateRequest(_ExpectExtensionsMessage):
         if state.version >= (3, 4):
             self._compare_extensions(cert_request)
             self._process_extensions(state, cert_request)
+            if self.context is not None:
+                self.context.append(cert_request)
 
         state.handshake_messages.append(cert_request)
         state.handshake_hashes.update(msg.write())

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -1199,6 +1199,22 @@ class CertificateVerifyGenerator(HandshakeProtocolMessageGenerator):
         return cert_verify
 
 
+class ClearContext(Command):
+    """
+    Object used to zero-out the context used in PHA.
+
+    This is necessary if the conversation is executed more than once.
+    """
+    def __init__(self, context):
+        super(ClearContext, self).__init__()
+        self.context = context
+
+    def process(self, state):
+        """Zero out the associated context"""
+        del state  # unused
+        self.context[:] = []
+
+
 class ChangeCipherSpecGenerator(MessageGenerator):
     """
     Generator for TLS Change Cipher Spec messages.

--- a/tlsfuzzer/runner.py
+++ b/tlsfuzzer/runner.py
@@ -23,6 +23,16 @@ class ConnectionState(object):
     @ivar handshake_hashes: all handhsake messages hashed
 
     @ivar handshake_messages: all hadshake messages exchanged between peers
+
+    @ivar key: various computed cryptographic keys, hashes and secrets related
+        to handshake and record layer
+
+        "premaster_secret" - premaster secret from TLS 1.2 and earlier
+
+        "client finished handshake hashes" - HandshakeHash object that has the
+        handshake hashes of last handshake (the only Handshake in TLS 1.3)
+        up to and including the client Finished; used for post-handshake
+        authentication
     """
 
     def __init__(self):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Implement support and add simple test case for post_handshake_auth extension

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

depends on: https://github.com/tomato42/tlslite-ng/pull/350, #543, https://github.com/tomato42/tlslite-ng/pull/379, https://github.com/tomato42/tlslite-ng/pull/380 and #501 
fixes #296 

filed #622 to handle the one remaining issue from codeclimate 

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [x] NSS ([MZBZ#1601402](https://bugzilla.mozilla.org/show_bug.cgi?id=1601402))
  - [x] GnuTLS (more or less, GnuTLS doesn't allow to test PHA in an automated way: [gnutls/gnutls#868](https://gitlab.com/gnutls/gnutls/issues/868))
- [x] required version of tlslite-ng updated in requirements.txt and README.md
- [x] test case includes interaction with KeyUpdate
- [x] test case includes interaction with NewSessionTicket (the test should verify that server sends at least one ticket)
- [x] support for servers that reject PHA with no client certificate with an alert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/551)
<!-- Reviewable:end -->
