### PR TITLE
test-signature-algorithms: extend test of unique, well-known sigalgs

### DIFF
--- a/scripts/test-signature-algorithms.py
+++ b/scripts/test-signature-algorithms.py
@@ -20,7 +20,7 @@ from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
         ExpectServerKeyExchange
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
-        HashAlgorithm, SignatureAlgorithm, ExtensionType
+        HashAlgorithm, SignatureAlgorithm, ExtensionType, SignatureScheme
 from tlslite.extensions import SignatureAlgorithmsExtension, \
         SignatureAlgorithmsCertExtension
 from tlsfuzzer.helpers import RSA_SIG_ALL
@@ -521,10 +521,21 @@ def main():
     ciphers = [CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
                CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    # Add all supported sig_algs, put rsa at the end
     sig_algs = []
-    for sig_alg in ['ecdsa', 'dsa', 'rsa']:
+    for sig_alg in ['ecdsa', 'dsa']:
         sig_algs += [(getattr(HashAlgorithm, x), getattr(SignatureAlgorithm, sig_alg))\
                       for x in ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']]
+    sig_algs += [SignatureScheme.rsa_pss_rsae_sha256,
+                 SignatureScheme.rsa_pss_rsae_sha384,
+                 SignatureScheme.rsa_pss_rsae_sha512,
+                 SignatureScheme.rsa_pss_pss_sha256,
+                 SignatureScheme.rsa_pss_pss_sha384,
+                 SignatureScheme.rsa_pss_pss_sha512] 
+    # ed25519(0x0807), ed448(0x0808)
+    sig_algs += [(8, 7), (8, 8)]
+    sig_algs += [(getattr(HashAlgorithm, x), getattr(SignatureAlgorithm, 'rsa'))\
+                 for x in ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']]
 
     ext = {ExtensionType.signature_algorithms :
            SignatureAlgorithmsExtension().create(sig_algs),
@@ -612,6 +623,8 @@ def main():
     print("Signature Algorithms in TLS 1.2")
     print("Check if valid signature algorithm extensions are accepted and")
     print("invalid properly rejected by the TLS 1.2 server.\n")
+    print("Server must be configured to support only rsa_pkcs1_sha512")
+    print("signature algorithm.")
     print("version: {0}\n".format(version))
 
     print("Test end")

--- a/scripts/test-tls13-signature-algorithms.py
+++ b/scripts/test-tls13-signature-algorithms.py
@@ -332,11 +332,19 @@ def main():
         .create([TLS_1_3_DRAFT, (3, 3)])
     ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
         .create(groups)
+    # Add all supported sig_algs, put rsa at the end
     sig_algs = []
-    for sig_alg in ['ecdsa', 'dsa']:
+    for sig_alg in ['ecdsa', 'dsa','rsa']:
         sig_algs += [(getattr(HashAlgorithm, x), getattr(SignatureAlgorithm, sig_alg))\
                       for x in ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']]
-    sig_algs += RSA_SIG_ALL
+    # ed25519(0x0807), ed448(0x0808)
+    sig_algs += [(8, 7), (8, 8)]
+    sig_algs += [SignatureScheme.rsa_pss_pss_sha256,
+                 SignatureScheme.rsa_pss_pss_sha384,
+                 SignatureScheme.rsa_pss_pss_sha512,
+                 SignatureScheme.rsa_pss_rsae_sha256,
+                 SignatureScheme.rsa_pss_rsae_sha384,
+                 SignatureScheme.rsa_pss_rsae_sha512]
     ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
         .create(sig_algs)
     ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
@@ -703,6 +711,8 @@ def main():
     print("Signature Algorithms in TLS 1.3")
     print("Check if valid signature algorithm extensions are accepted and")
     print("invalid properly rejected by the TLS 1.3 server.\n")
+    print("Server must be configured to support only rsa_pss_rsae_sha512")
+    print("signature algorithm.")
     print("version: {0}\n".format(version))
 
     print("Test end")


### PR DESCRIPTION
### Description

This change extends "unique and well-known sigalgs..." conversations by adding 

 * all RSA-PSS, ed25519 and ed448 in test-signature-algorithms.py and
 * ed25519 and ed448 in test-tls13-signature-algorithms.py.

This can be used to test that when ClientHello contain all well-known signature algorithms then it is not rejected even when server requires the last signature algorithm from the list (ie. rsa_pkcs1_sha512 and rsa_pss_rsae_sha512, respectively). 

### Motivation and Context

Fixes #558.

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [x] NSS
  - [ ] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/559)
<!-- Reviewable:end -->
