### PR TITLE
add a test that offers curves obsoleted in TLS 1.3

### DIFF
--- a/scripts/test-tls13-obsolete-curves.py
+++ b/scripts/test-tls13-obsolete-curves.py
@@ -1,0 +1,214 @@
+# Author: Alexander Sosedkin, (c) 2019
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+from itertools import chain
+from random import sample
+
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+        ExpectAlert, ExpectApplicationData, ExpectClose, \
+        ExpectEncryptedExtensions, ExpectCertificateVerify, \
+        ExpectNewSessionTicket
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+        TLS_1_3_DRAFT, GroupName, ExtensionType, SignatureScheme
+from tlslite.keyexchange import ECDHKeyExchange
+from tlsfuzzer.utils.lists import natural_sort_keys
+from tlslite.extensions import KeyShareEntry, ClientKeyShareExtension, \
+        SupportedVersionsExtension, SupportedGroupsExtension, \
+        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+from tlsfuzzer.helpers import key_share_gen, RSA_SIG_ALL
+
+
+version = 1
+
+
+def help_msg():
+    print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
+    print(" -h hostname    name of the host to run the test against")
+    print("                localhost by default")
+    print(" -p port        port number to use for connection, 4433 by default")
+    print(" probe-name     if present, will run only the probes with given")
+    print("                names and not all of them, e.g \"sanity\"")
+    print(" -e probe-name  exclude the probe from the list of the ones run")
+    print("                may be specified multiple times")
+    print(" -n num         only run `num` random tests instead of a full set")
+    print("                (\"sanity\" tests are always executed)")
+    print(" --help         this message")
+
+
+def main():
+    host = "localhost"
+    port = 4433
+    num_limit = None
+    run_exclude = set()
+
+    argv = sys.argv[1:]
+    opts, args = getopt.getopt(argv, "h:p:e:n:", ["help"])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '-e':
+            run_exclude.add(arg)
+        elif opt == '-n':
+            num_limit = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+
+    if args:
+        run_only = set(args)
+    else:
+        run_only = None
+
+    conversations = {}
+
+    conversation = Connect(host, port)
+    node = conversation
+    ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+               CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+    ext = {}
+    groups = [GroupName.secp256r1]
+    key_shares = []
+    for group in groups:
+        key_shares.append(key_share_gen(group))
+    ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+    ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+        .create([TLS_1_3_DRAFT, (3, 3)])
+    ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+        .create(groups)
+    sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                SignatureScheme.rsa_pss_pss_sha256]
+    ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+        .create(sig_algs)
+    ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+        .create(RSA_SIG_ALL)
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectEncryptedExtensions())
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectCertificateVerify())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+
+    # This message is optional and may show up 0 to many times
+    cycle = ExpectNewSessionTicket()
+    node = node.add_child(cycle)
+    node.add_child(cycle)
+
+    node.next_sibling = ExpectApplicationData()
+    node = node.next_sibling.add_child(AlertGenerator(AlertLevel.warning,
+                                       AlertDescription.close_notify))
+
+    node = node.add_child(ExpectAlert())
+    node.next_sibling = ExpectClose()
+    conversations["sanity"] = conversation
+
+    # https://tools.ietf.org/html/rfc8446#appendix-B.3.1.4
+    obsolete_groups = chain(range(0x0001, 0x0016 + 1),
+                            range(0x001A, 0x001C + 1),
+                            range(0xFF01, 0XFF02 + 1))
+
+    for obsolete_group in obsolete_groups:
+        obsolete_group_name = (GroupName.toRepr(obsolete_group)
+                               or "unknown ({0})".format(obsolete_group))
+        conversation = Connect(host, port)
+        node = conversation
+        ciphers = [CipherSuite.TLS_AES_128_GCM_SHA256,
+                   CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+        ext = {}
+        groups = [obsolete_group]
+        try:
+            key_shares = []
+            for group in groups:
+                key_shares.append(key_share_gen(group))
+        except ValueError:
+            # bogus value to move on, if it makes problems, these won't result in handshake_failure
+            key_shares = [KeyShareEntry().create(obsolete_group, bytearray(b'\xab'*32))]
+        ext[ExtensionType.key_share] = ClientKeyShareExtension().create(key_shares)
+        ext[ExtensionType.supported_versions] = SupportedVersionsExtension()\
+            .create([TLS_1_3_DRAFT, (3, 3)])
+        ext[ExtensionType.supported_groups] = SupportedGroupsExtension()\
+            .create(groups)
+        sig_algs = [SignatureScheme.rsa_pss_rsae_sha256,
+                    SignatureScheme.rsa_pss_pss_sha256]
+        ext[ExtensionType.signature_algorithms] = SignatureAlgorithmsExtension()\
+            .create(sig_algs)
+        ext[ExtensionType.signature_algorithms_cert] = SignatureAlgorithmsCertExtension()\
+            .create(RSA_SIG_ALL)
+        node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+        node = node.add_child(ExpectAlert(AlertLevel.fatal,
+                                          AlertDescription.handshake_failure))
+
+        node = node.add_child(ExpectClose())
+        conversation_name = "{0} should be handshake_failed in TLS 1.3".format(obsolete_group_name)
+        conversations[conversation_name] = conversation
+
+    # run the conversation
+    good = 0
+    bad = 0
+    failed = []
+    if not num_limit:
+        num_limit = len(conversations)
+
+    # make sure that sanity test is run first and last
+    # to verify that server was running and kept running throughout
+    sanity_tests = [('sanity', conversations['sanity'])]
+    regular_tests = [(k, v) for k, v in conversations.items() if k != 'sanity']
+    sampled_tests = sample(regular_tests, min(num_limit, len(regular_tests)))
+    ordered_tests = chain(sanity_tests, sampled_tests, sanity_tests)
+
+    for c_name, c_test in ordered_tests:
+        if run_only and c_name not in run_only or c_name in run_exclude:
+            continue
+        print("{0} ...".format(c_name))
+
+        runner = Runner(c_test)
+
+        res = True
+        try:
+            runner.run()
+        except Exception:
+            print("Error while processing")
+            print(traceback.format_exc())
+            res = False
+
+        if res:
+            good += 1
+            print("OK\n")
+        else:
+            bad += 1
+            failed.append(c_name)
+
+    print("Negotiating obsolete curves with TLS 1.3 server")
+    print("Check that TLS 1.3 server will not use obsolete curves and")
+    print("will reject the connection with handshake_failure alert.")
+    print("Reproduces https://github.com/openssl/openssl/issues/8369\n")
+    print("version: {0}\n".format(version))
+
+    print("Test end")
+    print("successful: {0}".format(good))
+    print("failed: {0}".format(bad))
+    failed_sorted = sorted(failed, key=natural_sort_keys)
+    print("  {0}".format('\n  '.join(repr(i) for i in failed_sorted)))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -263,6 +263,7 @@
           "comment" : "several tls12 extensions must be excluded, tlslite-ng issue #314"},
          {"name" : "test-tls13-legacy-version.py"},
          {"name" : "test-tls13-nociphers.py"},
+         {"name" : "test-tls13-obsolete-curves.py"},
          {"name" : "test-tls13-pkcs-signature.py"},
          {"name" : "test-tls13-record-layer-limits.py",
           "arguments" : ["-n", "50"]},

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -244,6 +244,7 @@
           "comment" : "several tls12 extensions must be excluded, tlslite-ng issue #314"},
          {"name" : "test-tls13-legacy-version.py"},
          {"name" : "test-tls13-nociphers.py"},
+         {"name" : "test-tls13-obsolete-curves.py"},
          {"name" : "test-tls13-pkcs-signature.py"},
          {"name" : "test-tls13-record-layer-limits.py"},
          {"name" : "test-tls13-record-padding.py"},


### PR DESCRIPTION
### Description

The test offers curves obsoleted in TLS 1.3, like secp256k1 or brainpool. They should be handshake_failed.

### Motivation and Context

openssl allows one to negotiate TLS <1.3 curves in TLS 1.3 (https://github.com/openssl/openssl/issues/8369). This is a reproducer for that.

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [X] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [X] new and modified scripts were ran against popular TLS implementations:
  - [X] OpenSSL
  - [X] NSS
  - [X] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/569)
<!-- Reviewable:end -->
