### PR TITLE
test-encrypt-then-mac-renegotiation: fix exts

### DIFF
--- a/scripts/test-encrypt-then-mac-renegotiation.py
+++ b/scripts/test-encrypt-then-mac-renegotiation.py
@@ -114,6 +114,8 @@ def main():
     node = node.add_child(ClientHelloGenerator(ciphers,
                                                session_id=bytearray(0),
                                                extensions=extensions))
+    extensions = {ExtensionType.encrypt_then_mac:None,
+                  ExtensionType.renegotiation_info:None}
     node = node.add_child(ExpectServerHello(extensions=extensions))
     node = node.add_child(ExpectCertificate())
     node = node.add_child(ExpectServerHelloDone())


### PR DESCRIPTION
### Description
ExpectServerHello was passed an AutoEmptyExtension for encrypt_then_mac.
Changed it to None so that it expects one from ClientHello.

### Motivation and Context
To make the test work again.

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [x] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/575)
<!-- Reviewable:end -->
