### PR TITLE
client-hello-max-size: add support for DHE ciphers

### DIFF
--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -46,6 +46,8 @@
           "comment" : "over 150 test cases in script"},
          {"name" : "test-clienthello-md5.py"},
          {"name" : "test-client-hello-max-size.py" },
+         {"name" : "test-client-hello-max-size.py",
+          "arguments" : ["-d"]},
          {"name" : "test-client-compatibility.py",
           "arguments" : ["-e", "18: IE 6 on XP",
                          "-e", "52: YandexBot 3.0 on unknown",

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -43,6 +43,8 @@
          {"name" : "test-chacha20.py" },
          {"name" : "test-clienthello-md5.py"},
          {"name" : "test-client-hello-max-size.py" },
+         {"name" : "test-client-hello-max-size.py",
+          "arguments" : ["-d"]},
          {"name" : "test-client-compatibility.py",
           "arguments" : ["-e", "18: IE 6 on XP",
                          "-e", "52: YandexBot 3.0 on unknown",


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
add support for ECDHE and DHE ciphers in `test-client-hello-max-size.py` script

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
#563 

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [X] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md
