### PR TITLE
Large records

### DIFF
--- a/scripts/test-atypical-padding.py
+++ b/scripts/test-atypical-padding.py
@@ -27,7 +27,8 @@ from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 from tlslite.utils.compat import compatAscii2Bytes
 
-version = 2
+
+version = 3
 
 
 def help_msg():
@@ -42,6 +43,9 @@ def help_msg():
     print(" -n num         only run `num` random tests instead of a full set")
     print("                (\"sanity\" tests are always executed)")
     print(" -d             negotiate (EC)DHE instead of RSA key exchange")
+    print(" --echo-headers expect the server to echo the headers (so its reply")
+    print("                will be split over two ApplicationData records, not")
+    print("                one for the tests with 2**14 byte payload)")
     print(" --help         this message")
 
 
@@ -64,9 +68,10 @@ def main():
     num_limit = None
     run_exclude = set()
     dhe = False
+    echo = False
 
     argv = sys.argv[1:]
-    opts, args = getopt.getopt(argv, "h:p:e:n:d", ["help"])
+    opts, args = getopt.getopt(argv, "h:p:e:n:d", ["help", "echo-headers"])
     for opt, arg in opts:
         if opt == '-h':
             host = arg
@@ -81,6 +86,8 @@ def main():
         elif opt == '--help':
             help_msg()
             sys.exit(0)
+        elif opt == '--echo-headers':
+            echo = True
         else:
             raise ValueError("Unknown option: {0}".format(opt))
 
@@ -372,6 +379,8 @@ def main():
     assert len(text) == 2**14, len(text)
     node = node.add_child(fuzz_padding(ApplicationDataGenerator(text),
                                        min_length=252))
+    if echo:
+        node = node.add_child(ExpectApplicationData(size=2**14))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
@@ -417,6 +426,8 @@ def main():
     assert len(text) == 2**14, len(text)
     node = node.add_child(fuzz_padding(ApplicationDataGenerator(text),
                                        min_length=255))
+    if echo:
+        node = node.add_child(ExpectApplicationData(size=2**14))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
@@ -462,6 +473,8 @@ def main():
     assert len(text) == 2**14, len(text)
     node = node.add_child(fuzz_padding(ApplicationDataGenerator(text),
                                        min_length=255))
+    if echo:
+        node = node.add_child(ExpectApplicationData(size=2**14))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))
@@ -498,6 +511,8 @@ def main():
     assert len(text) == 2**14, len(text)
     node = node.add_child(fuzz_padding(ApplicationDataGenerator(text),
                                        min_length=255))
+    if echo:
+        node = node.add_child(ExpectApplicationData(size=2**14))
     node = node.add_child(ExpectApplicationData())
     node = node.add_child(AlertGenerator(AlertLevel.warning,
                                          AlertDescription.close_notify))


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
extend the tests for padding in CBC ciphersuites, allow the tests to execute in FIPS mode

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
https://gitlab.com/gnutls/gnutls/merge_requests/1054

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
       - already in those scripts, not limited
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [x] NSS [MZBZ#1580286](https://bugzilla.mozilla.org/show_bug.cgi?id=1580286)
  - [x] GnuTLS [gnutls#811](https://gitlab.com/gnutls/gnutls/issues/811)
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/585)
<!-- Reviewable:end -->
