### PR TITLE
test-export-ciphers-rejected.py: add -d for DH key exchange

### DIFF
--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -127,6 +127,8 @@
          {"name" : "test-export-ciphers-rejected.py",
           "comment": "tlslite-ng doesn't support SSLv3 by default",
           "arguments": ["--min-ver", "TLSv1.0"]},
+         {"name" : "test-export-ciphers-rejected.py",
+          "arguments" : ["-d", "--min-ver", "TLSv1.0"]},
          {"name" : "test-extensions.py"},
          {"name" : "test-extended-master-secret-extension.py",
           "arguments" : ["-e", "extended master secret with renegotiation",

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -121,6 +121,8 @@
          {"name" : "test-export-ciphers-rejected.py",
           "comment": "tlslite-ng doesn't support SSLv3 by default",
           "arguments": ["--min-ver", "TLSv1.0"]},
+         {"name" : "test-export-ciphers-rejected.py",
+          "arguments": ["-d", "--min-ver", "TLSv1.0"]},
          {"name" : "test-extensions.py"},
          {"name" : "test-extended-master-secret-extension.py",
           "arguments" : ["-e", "extended master secret with renegotiation",


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Add -d switch for test-export-ciphers-rejected which enables DH key exchange instead of RSA
### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
#563 
### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [x] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/586)
<!-- Reviewable:end -->
