### PR TITLE
update expected sigalgs to new tlslite-ng version

### DIFF
--- a/scripts/test-certificate-request.py
+++ b/scripts/test-certificate-request.py
@@ -31,7 +31,7 @@ from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 
 
-version = 2
+version = 3
 
 
 def help_msg():
@@ -59,7 +59,12 @@ def main():
     cert = None
     private_key = None
 
-    sigalgs = [SignatureScheme.rsa_pss_rsae_sha512,
+    sigalgs = [SignatureScheme.ecdsa_secp521r1_sha512,
+               SignatureScheme.ecdsa_secp384r1_sha384,
+               SignatureScheme.ecdsa_secp256r1_sha256,
+               (HashAlgorithm.sha224, SignatureAlgorithm.ecdsa),
+               (HashAlgorithm.sha1, SignatureAlgorithm.ecdsa),
+               SignatureScheme.rsa_pss_rsae_sha512,
                SignatureScheme.rsa_pss_pss_sha512,
                SignatureScheme.rsa_pss_rsae_sha384,
                SignatureScheme.rsa_pss_pss_sha384,

--- a/scripts/test-certificate-verify-malformed.py
+++ b/scripts/test-certificate-verify-malformed.py
@@ -37,6 +37,9 @@ def natural_sort_keys(s, _nsre=re.compile('([0-9]+)')):
             for text in re.split(_nsre, s)]
 
 
+version = 2
+
+
 def help_msg():
     print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
     print(" -h hostname    name of the host to run the test against")
@@ -217,7 +220,7 @@ def main():
         node = node.add_child(CertificateGenerator(X509CertChain([cert])))
         node = node.add_child(ClientKeyExchangeGenerator())
         node = node.add_child(TCPBufferingFlush())
-        node = node.add_child(CertificateVerifyGenerator(signature=sig[:i]))
+        node = node.add_child(CertificateVerifyGenerator(private_key, signature=sig[:i]))
         node = node.add_child(ChangeCipherSpecGenerator())
         node = node.add_child(FinishedGenerator())
         node = node.add_child(TCPBufferingDisable())
@@ -333,7 +336,8 @@ def main():
             bad += 1
             failed.append(c_name)
 
-    print("Malformed CertificateVerify test version 1\n")
+    print("Malformed CertificateVerify test\n")
+    print("version: {0}\n".format(version))
     print("Test end")
     print("successful: {0}".format(good))
     print("failed: {0}".format(bad))

--- a/scripts/test-rsa-pss-sigs-on-certificate-verify.py
+++ b/scripts/test-rsa-pss-sigs-on-certificate-verify.py
@@ -32,7 +32,7 @@ from tlslite.x509certchain import X509CertChain
 from tlslite.utils.cryptomath import numBytes
 
 
-version = 3
+version = 4
 
 
 def help_msg():
@@ -71,7 +71,12 @@ def main():
     cert = None
     exp_illeg_param = False
 
-    sigalgs = [SignatureScheme.rsa_pss_rsae_sha512,
+    sigalgs = [SignatureScheme.ecdsa_secp521r1_sha512,
+               SignatureScheme.ecdsa_secp384r1_sha384,
+               SignatureScheme.ecdsa_secp256r1_sha256,
+               (HashAlgorithm.sha224, SignatureAlgorithm.ecdsa),
+               (HashAlgorithm.sha1, SignatureAlgorithm.ecdsa),
+               SignatureScheme.rsa_pss_rsae_sha512,
                SignatureScheme.rsa_pss_pss_sha512,
                SignatureScheme.rsa_pss_rsae_sha384,
                SignatureScheme.rsa_pss_pss_sha384,

--- a/scripts/test-tls13-certificate-request.py
+++ b/scripts/test-tls13-certificate-request.py
@@ -34,7 +34,7 @@ from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 
 
-version = 1
+version = 2
 
 
 def help_msg():
@@ -61,7 +61,12 @@ def main():
     cert = None
     private_key = None
 
-    sigalgs = [SignatureScheme.rsa_pss_rsae_sha512,
+    sigalgs = [SignatureScheme.ecdsa_secp521r1_sha512,
+               SignatureScheme.ecdsa_secp384r1_sha384,
+               SignatureScheme.ecdsa_secp256r1_sha256,
+               (HashAlgorithm.sha224, SignatureAlgorithm.ecdsa),
+               (HashAlgorithm.sha1, SignatureAlgorithm.ecdsa),
+               SignatureScheme.rsa_pss_rsae_sha512,
                SignatureScheme.rsa_pss_pss_sha512,
                SignatureScheme.rsa_pss_rsae_sha384,
                SignatureScheme.rsa_pss_pss_sha384,

--- a/scripts/test-tls13-certificate-verify.py
+++ b/scripts/test-tls13-certificate-verify.py
@@ -36,7 +36,7 @@ from tlslite.x509 import X509
 from tlslite.x509certchain import X509CertChain
 
 
-version = 2
+version = 3
 
 
 def help_msg():
@@ -119,7 +119,12 @@ def main():
     private_key = None
 
     # algorithms to expect from server in Certificate Request
-    cr_sigalgs = [SignatureScheme.rsa_pss_rsae_sha512,
+    cr_sigalgs = [SignatureScheme.ecdsa_secp521r1_sha512,
+                  SignatureScheme.ecdsa_secp384r1_sha384,
+                  SignatureScheme.ecdsa_secp256r1_sha256,
+                  (HashAlgorithm.sha224, SignatureAlgorithm.ecdsa),
+                  (HashAlgorithm.sha1, SignatureAlgorithm.ecdsa),
+                  SignatureScheme.rsa_pss_rsae_sha512,
                   SignatureScheme.rsa_pss_pss_sha512,
                   SignatureScheme.rsa_pss_rsae_sha384,
                   SignatureScheme.rsa_pss_pss_sha384,


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
fix the test suite after ECDSA addition

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
make the test suite pass again after tlslite-ng with ECDSA support was released

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/599)
<!-- Reviewable:end -->
