### PR TITLE
Remove leftover .gitmodules file.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "tlslite-ng"]
-	path = tlslite-ng
-	url = https://github.com/tomato42/tlslite-ng.git
-	branch = recordlayer-helpers


### PR DESCRIPTION
### Description
In commit 34299af441c7d70eff8de186a2b089cd8a3b6d97 tlslite-ng submodule
was removed but .gitmodules file wasn't for some reason deleted.

### Motivation and Context
If submodule fetching scripting relies only on .gitmodules for pulling submodules the script can fail as the tlsfuzzer repository doesn't really have the submodule configured. And in general nice to tidy things.

### Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/600)
<!-- Reviewable:end -->
