### PR TITLE
test-fuzzed-plaintext: use SIG_ALL

### DIFF
--- a/scripts/test-fuzzed-plaintext.py
+++ b/scripts/test-fuzzed-plaintext.py
@@ -22,7 +22,7 @@ from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
         ExpectApplicationData, ExpectServerKeyExchange
 from tlsfuzzer.fuzzers import structured_random_iter, StructuredRandom
 from tlsfuzzer.utils.lists import natural_sort_keys
-from tlsfuzzer.helpers import RSA_SIG_ALL
+from tlsfuzzer.helpers import SIG_ALL
 
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
         GroupName, ExtensionType
@@ -30,7 +30,7 @@ from tlslite.extensions import SupportedGroupsExtension, \
         SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
 
 
-version = 5
+version = 6
 
 
 def help_msg():
@@ -76,9 +76,9 @@ def add_dhe_extensions(extensions):
     extensions[ExtensionType.supported_groups] = SupportedGroupsExtension()\
         .create(groups)
     extensions[ExtensionType.signature_algorithms] = \
-        SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
+        SignatureAlgorithmsExtension().create(SIG_ALL)
     extensions[ExtensionType.signature_algorithms_cert] = \
-        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
+        SignatureAlgorithmsCertExtension().create(SIG_ALL)
 
 
 def add_app_data_conversation(conversations, host, port, cipher, dhe, data):

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -547,6 +547,9 @@
           "arguments": ["-d"]
          },
          {"name": "test-ecdsa-sig-flexibility.py"},
+         {"name": "test-fuzzed-plaintext.py",
+          "arguments" : ["-n", "50", "--random", "200",
+              "-C", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"]},
          {"name": "test-tls13-conversation.py"},
          {"name": "test-tls13-ecdsa-support.py",
           "comments": "tlslite can't load multiple ECDSA keys at the same time",

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -516,6 +516,8 @@
           "arguments": ["-d"]
          },
          {"name": "test-ecdsa-sig-flexibility.py"},
+         {"name": "test-fuzzed-plaintext.py",
+          "arguments" : ["-C", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"]},
          {"name": "test-tls13-conversation.py"},
          {"name": "test-tls13-ecdsa-support.py",
           "comments": "tlslite can't load multiple ECDSA keys at the same time",


### PR DESCRIPTION
### Description
Advertise `SIG_ALL` instead of `RSA_SIG_ALL` in test-fuzzed-plaintext.

### Motivation and Context
While one could select any cipher with `-C`, signature algorithms selection was previously limited to `RSA_SIG_ALL`. A relevant usage example is added to tests/tlslite-ng*.json

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL
  - [x] NSS
  - [x] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/616)
<!-- Reviewable:end -->
