### PR TITLE
Update the implicit no-sha1 check

### DIFF
--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -1084,6 +1084,8 @@ class ExpectServerKeyExchange(ExpectHandshake):
             if valid_sig_algs is None:
                 # no advertised means support for sha1 only
                 valid_sig_algs = [(HashAlgorithm.sha1, SignatureAlgorithm.rsa)]
+                if self.cipher_suite in CipherSuite.ecdheEcdsaSuites:
+                    valid_sig_algs = [(HashAlgorithm.sha1, SignatureAlgorithm.ecdsa)]
 
         try:
             KeyExchange.verifyServerKeyExchange(server_key_exchange,


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
When no-sha1 switch is used the implicit sha1 connection can fail right away or after the ExpectCertificate message.
### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
There is no open issues for this but ext was not initialized and the script was expecting the implicit sha1 to fail right away.
### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [x] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/618)
<!-- Reviewable:end -->
