### PR TITLE
test-encrypt-then-mac-renegotiation: -d for (EC)DHE

### DIFF
--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -143,6 +143,15 @@
           "comment" : "Test requires renegotiation support",
           "exp_pass" : false
          },
+         {"name" : "test-encrypt-then-mac-renegotiation.py",
+          "arguments" : ["-d", "-e", "Encrypt-then-MAC renegotiation crash"],
+          "comment" : "Test requires renegotiation support"
+         },
+         {"name" : "test-encrypt-then-mac-renegotiation.py",
+          "arguments" : ["-d", "Encrypt-then-MAC renegotiation crash"],
+          "comment" : "Test requires renegotiation support",
+          "exp_pass" : false
+         },
          {"name" : "test-export-ciphers-rejected.py",
           "comment": "tlslite-ng doesn't support SSLv3 by default",
           "arguments": ["--min-ver", "TLSv1.0"]},

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -137,6 +137,15 @@
           "comment" : "Test requires renegotiation support",
           "exp_pass" : false
          },
+         {"name" : "test-encrypt-then-mac-renegotiation.py",
+          "arguments" : ["-d", "-e", "Encrypt-then-MAC renegotiation crash"],
+          "comment" : "Test requires renegotiation support"
+         },
+         {"name" : "test-encrypt-then-mac-renegotiation.py",
+          "arguments" : ["-d", "Encrypt-then-MAC renegotiation crash"],
+          "comment" : "Test requires renegotiation support",
+          "exp_pass" : false
+         },
          {"name" : "test-export-ciphers-rejected.py",
           "comment": "tlslite-ng doesn't support SSLv3 by default",
           "arguments": ["--min-ver", "TLSv1.0"]},


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Add an option to negotiate (EC)DHE instead of RSA key exchange
for scripts/test-encrypt-then-mac-renegotiation.py

### Motivation and Context
See the #563 (umbrella bug) for the context.

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - [x] OpenSSL (OK)
  - [x] NSS (fails, MZBZ#972145 WONTFIX)
  - [x] GnuTLS (OK)
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/624)
<!-- Reviewable:end -->
