### PR TITLE
Modified the script so that when you run it it first loads all of the…

### DIFF
--- a/tests/verify-scripts-json.py
+++ b/tests/verify-scripts-json.py
@@ -9,31 +9,36 @@ from sys import argv
 parent_dir = dirname(dirname(abspath(__file__)))
 scriptlist = [f for f in listdir(os.path.join(parent_dir,'scripts')) if isfile(join(os.path.join(parent_dir,'scripts'), f))]
 status = 0
+jsonfile = []
 for arg in argv[1:]:
     missing = []
     try:
-        jsonfile = json.load(open(arg))
+        jsonfile.append(json.load(open(arg)))
     except IOError:
-        print("Please check the input file name, it doesn't appear to exist")
+        print("Please check the '{0}'  file name, it doesn't appear to exist".format(arg))
         status =1
+        exit(status)
         continue
     except ValueError:
-        print("Wrong file type: The input must be a json file")
+        print("Wrong file type:'.{0}' -  The input must be a json file".format(arg.split('.')[1]))
         status =1
+        exit(status)
         continue
     except IndexError:
         print("No input file was provided")
         status =1
+        exit(status)
         continue
-    for f in scriptlist:
-        if f not in str(jsonfile):
-            missing.append(f)
-    if not missing:
-        print(" All scripts are in the json file")
-    else:
-        print("There are {0} scripts that are missing from {1}:".format(len(missing), arg))
-        print("\n".join(missing))
-        status = 1
+
+for f in scriptlist:
+    if f not in str(jsonfile):
+        missing.append(f)
+if not missing:
+    print(" All scripts are in the json file")
+else:
+    print("There are {0} scripts that are missing from {1}:".format(len(missing), arg))
+    print("\n".join(missing))
+    status = 1
 
 missing = []
 for test_script in scriptlist:


### PR DESCRIPTION
Modified the script so that when you run it it first loads all of the json files and then it checks if at least one of them contains each of the scripts from the /scripts folder

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/642)
<!-- Reviewable:end -->
