### PR TITLE
Tests default values

### DIFF
--- a/scripts/test-bleichenbacher-workaround.py
+++ b/scripts/test-bleichenbacher-workaround.py
@@ -55,7 +55,7 @@ def main():
     """Check if server is not vulnerable to Bleichenbacher attack"""
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 50
     run_exclude = set()
     timeout = 1.0
     alert = AlertDescription.bad_record_mac

--- a/scripts/test-chacha20.py
+++ b/scripts/test-chacha20.py
@@ -45,7 +45,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 50
     run_exclude = set()
 
     argv = sys.argv[1:]

--- a/scripts/test-client-compatibility.py
+++ b/scripts/test-client-compatibility.py
@@ -57,7 +57,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 50
     run_exclude = set()
     dhe = False
 

--- a/scripts/test-cve-2016-7054.py
+++ b/scripts/test-cve-2016-7054.py
@@ -44,7 +44,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 50
     run_exclude = set()
 
     argv = sys.argv[1:]

--- a/scripts/test-ecdsa-in-certificate-verify.py
+++ b/scripts/test-ecdsa-in-certificate-verify.py
@@ -55,7 +55,7 @@ def main():
     """check if obsolete signature algorithm is rejected by server"""
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 10
     run_exclude = set()
     private_key = None
     cert = None

--- a/scripts/test-fuzzed-plaintext.py
+++ b/scripts/test-fuzzed-plaintext.py
@@ -191,7 +191,7 @@ def main():
     """Check if incorrect padding and MAC is rejected by server."""
     host = "localhost"
     port = 4433
-    num_limit = 1024
+    num_limit = 80
     rand_limit = None
     run_exclude = set()
     dhe = False

--- a/scripts/test-invalid-client-hello-w-record-overflow.py
+++ b/scripts/test-invalid-client-hello-w-record-overflow.py
@@ -39,7 +39,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 500
     run_exclude = set()
 
     argv = sys.argv[1:]

--- a/scripts/test-invalid-client-hello.py
+++ b/scripts/test-invalid-client-hello.py
@@ -44,7 +44,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 50
     run_exclude = set()
 
     argv = sys.argv[1:]

--- a/scripts/test-large-hello.py
+++ b/scripts/test-large-hello.py
@@ -43,7 +43,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 50
     min_ext = 52
     run_exclude = set()
 

--- a/scripts/test-rsa-pss-sigs-on-certificate-verify.py
+++ b/scripts/test-rsa-pss-sigs-on-certificate-verify.py
@@ -65,7 +65,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 15
     run_exclude = set()
     private_key = None
     cert = None

--- a/scripts/test-ssl-death-alert.py
+++ b/scripts/test-ssl-death-alert.py
@@ -53,7 +53,7 @@ def help_msg():
 def main():
     hostname = "localhost"
     port = 4433
-    number_of_alerts = 4
+    number_of_alerts = 0
     run_exclude = set()
     alert_level = AlertLevel.fatal
     alert_description = None

--- a/scripts/test-tls13-certificate-verify.py
+++ b/scripts/test-tls13-certificate-verify.py
@@ -113,7 +113,7 @@ def main():
     """Check that server propoerly rejects pkcs1 signatures in TLS 1.3"""
     hostname = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 10
     run_exclude = set()
     cert = None
     private_key = None

--- a/scripts/test-tls13-finished-plaintext.py
+++ b/scripts/test-tls13-finished-plaintext.py
@@ -49,7 +49,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 50
     run_exclude = set()
 
     argv = sys.argv[1:]

--- a/scripts/test-tls13-finished.py
+++ b/scripts/test-tls13-finished.py
@@ -49,7 +49,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 40
     run_exclude = set()
 
     argv = sys.argv[1:]

--- a/scripts/test-tls13-keyupdate.py
+++ b/scripts/test-tls13-keyupdate.py
@@ -54,7 +54,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 60
     run_exclude = set()
     coalescing = False
 

--- a/scripts/test-tls13-large-number-of-extensions.py
+++ b/scripts/test-tls13-large-number-of-extensions.py
@@ -58,7 +58,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 20
     run_exclude = set()
     ext_exclude = set()
     exp_sup_groups = False

--- a/scripts/test-tls13-record-layer-limits.py
+++ b/scripts/test-tls13-record-layer-limits.py
@@ -56,7 +56,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 50
     run_exclude = set()
 
     argv = sys.argv[1:]

--- a/scripts/test-tls13-signature-algorithms.py
+++ b/scripts/test-tls13-signature-algorithms.py
@@ -51,7 +51,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 100
     fatal_alert = "decode_error"
     run_exclude = set()
 

--- a/scripts/test-tls13-symetric-ciphers.py
+++ b/scripts/test-tls13-symetric-ciphers.py
@@ -50,7 +50,7 @@ def help_msg():
 def main():
     host = "localhost"
     port = 4433
-    num_limit = None
+    num_limit = 100
     run_exclude = set()
 
     argv = sys.argv[1:]


### PR DESCRIPTION
Changed default 'num_limit' values in some tests from: '/scripts' so t…hat they run for max of 10s on mid-range computer

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/645)
<!-- Reviewable:end -->
