### PR TITLE
Edited script_retention.py

### DIFF
--- a/tests/scripts_retention.py
+++ b/tests/scripts_retention.py
@@ -109,11 +109,12 @@ def flush_queue():
             break
 
 
-def run_clients(tests, srv, expected_size):
+def run_clients(tests,common_args, srv, expected_size):
     good = 0
     bad = 0
     failed = []
     print_all_from_queue()
+    
     for params in tests:
         script = params["name"]
         logger.info("{0}:started".format(script))
@@ -123,7 +124,15 @@ def run_clients(tests, srv, expected_size):
         arguments = params.get("arguments", [])
         arguments = [expected_size if arg == "{expected_size}" else arg for
                      arg in arguments]
-        proc_args.extend(arguments)
+        to_delete = []
+        for number, arg in enumerate(common_args):
+           if (arg in arguments) and ('-' in str(common_args[number])):
+                to_delete.append(number)
+                if not '-' in str(common_args[number+1]):
+                    to_delete.append(number+1)
+        for index in sorted(to_delete, reverse=True):
+            del common_args[index] 
+        proc_args.extend(common_args + arguments)
         my_env = os.environ.copy()
         my_env["PYTHONPATH"]="."
         proc = Popen(proc_args, env=my_env,
@@ -178,9 +187,10 @@ def run_with_json(config_file, srv_path, expected_size):
                                              server_host,
                                              server_port)
         logger.info("Server process started")
-
+        
+        common_args = srv_conf.get("common_arguments", [])
         try:
-            n_good, n_bad, f_cmds = run_clients(srv_conf["tests"], srv,
+            n_good, n_bad, f_cmds = run_clients(srv_conf["tests"],common_args, srv,
                                                 expected_size)
             good += n_good
             bad += n_bad


### PR DESCRIPTION
New chages will accept "common_arguments" as a parametr of server so that all tests in specific server will run given arguments.
Also "arguments" will overwrite these "common_arguments" so that you can make exceptions in specific tests.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [ ] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md
