### PR TITLE
fix py3.7 and py3.8 execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,27 @@
-language: python
-
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - 3.6
-  - 3.7
-  - 3.8
-
 # workaround for 3.7 and 3.8 not available in default configuration
 # travis-ci/travis-ci#9815
 dist: trusty
 sudo: false
+cache: pip
+language: python
 
-matrix:
- exclude:
-   - python: 3.7
-   - python: 3.8
+addons:
+  apt_packages:
+    # needed for M2Crypto
+    - swig
+    - libssl-dev
+
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log
+
+jobs:
  include:
+   - python: 2.6
+   - python: 2.7
+   - python: 3.3
+   - python: 3.4
+   - python: 3.5
+   - python: 3.6
 # workaround for 3.7 and 3.8 not available in default configuration
 # travis-ci/travis-ci#9815
    - python: 3.7
@@ -32,12 +34,6 @@ matrix:
 branches:
   only:
     - master
-
-addons:
-  apt_packages:
-    # needed for M2Crypto
-    - swig
-    - libssl-dev
 
 before_install:
   - |
@@ -108,8 +104,6 @@ script:
         done
       fi
 
-sudo: false
-
 after_success:
- - coveralls
+ - travis_retry coveralls
  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then coverage xml; ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi


### PR DESCRIPTION

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
make the tests execute on Python 3.7 and Python 3.8 again

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
more complete test coverage
fix recent regression caused by changes in travis

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/665)
<!-- Reviewable:end -->
