### PR TITLE
FFDH parameter matching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-tlslite-ng>=0.8.0-alpha37
+tlslite-ng>=0.8.0-alpha38

--- a/scripts/test-ffdhe-expected-params.py
+++ b/scripts/test-ffdhe-expected-params.py
@@ -105,7 +105,14 @@ def main():
     if not group_names and not dh_file:
         group_names = ["RFC7919 ffdhe2048"]
 
-    valid_params = set(FFDHE_PARAMETERS[i] for i in group_names)
+    try:
+        valid_params = set(FFDHE_PARAMETERS[i] for i in group_names)
+    except KeyError as e:
+        raise ValueError(
+            "Unrecognised group name: {0}, known names: {1}"
+            .format(str(e),
+                ", ".join("'{0}'".format(i) for i in
+                          FFDHE_PARAMETERS.keys())))
 
     if dh_file:
         with open(dh_file, "r") as f:

--- a/scripts/test-ffdhe-expected-params.py
+++ b/scripts/test-ffdhe-expected-params.py
@@ -1,0 +1,259 @@
+# Author: Hubert Kario, (c) 2020
+# Released under Gnu GPL v2.0, see LICENSE file for details
+
+"""Minimal test for verifying server-selected DH parameters"""
+
+from __future__ import print_function
+import traceback
+import sys
+import getopt
+from itertools import chain
+from random import sample
+
+from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
+        ExtensionType
+from tlslite.extensions import \
+        SignatureAlgorithmsExtension, SignatureAlgorithmsCertExtension
+from tlslite.mathtls import FFDHE_PARAMETERS
+from tlsfuzzer.runner import Runner
+from tlsfuzzer.messages import Connect, ClientHelloGenerator, \
+        ClientKeyExchangeGenerator, ChangeCipherSpecGenerator, \
+        FinishedGenerator, ApplicationDataGenerator, AlertGenerator
+from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
+        ExpectServerHelloDone, ExpectChangeCipherSpec, ExpectFinished, \
+        ExpectAlert, ExpectClose, ExpectServerKeyExchange, \
+        ExpectApplicationData
+from tlsfuzzer.utils.lists import natural_sort_keys
+from tlsfuzzer.helpers import RSA_SIG_ALL
+
+
+version = 1
+
+
+def help_msg():
+    print("Usage: <script-name> [-h hostname] [-p port] [[probe-name] ...]")
+    print(" -h hostname    name of the host to run the test against")
+    print("                localhost by default")
+    print(" -p port        port number to use for connection, 4433 by default")
+    print(" probe-name     if present, will run only the probes with given")
+    print("                names and not all of them, e.g \"sanity\"")
+    print(" -e probe-name  exclude the probe from the list of the ones run")
+    print("                may be specified multiple times")
+    print(" -x probe-name  expect the probe to fail. When such probe passes despite being marked like this")
+    print("                it will be reported in the test summary and the whole script will fail.")
+    print("                May be specified multiple times.")
+    print(" -X message     expect the `message` substring in exception raised during")
+    print("                execution of preceding expected failure probe")
+    print("                usage: [-x probe-name] [-X exception], order is compulsory!")
+    print(" -n num         run 'num' or all(if 0) tests instead of default(all)")
+    print("                (excluding \"sanity\" tests)")
+    print(" --named-ffdh   Name of the well-known FFDHE parameters that the server can use")
+    print("                can be used multiple times to specify multiple valid groups")
+    print("                \"RFC7919 ffdhe2048\" by default")
+    print(" --help         this message")
+
+
+def main():
+    """Test what DH parameters server selects for exchange"""
+    host = "localhost"
+    port = 4433
+    num_limit = None
+    run_exclude = set()
+    expected_failures = {}
+    last_exp_tmp = None
+    group_names = []
+
+    argv = sys.argv[1:]
+    opts, args = getopt.getopt(argv, "h:p:e:x:X:n:", ["help", "named-ffdh="])
+    for opt, arg in opts:
+        if opt == '-h':
+            host = arg
+        elif opt == '-p':
+            port = int(arg)
+        elif opt == '-e':
+            run_exclude.add(arg)
+        elif opt == '-x':
+            expected_failures[arg] = None
+            last_exp_tmp = str(arg)
+        elif opt == '-X':
+            if not last_exp_tmp:
+                raise ValueError("-x has to be specified before -X")
+            expected_failures[last_exp_tmp] = str(arg)
+        elif opt == '-n':
+            num_limit = int(arg)
+        elif opt == '--help':
+            help_msg()
+            sys.exit(0)
+        elif opt == '--named-ffdh':
+            group_names.append(arg)
+        else:
+            raise ValueError("Unknown option: {0}".format(opt))
+
+    if args:
+        run_only = set(args)
+    else:
+        run_only = None
+
+    if not group_names:
+        group_names = ["RFC7919 ffdhe2048"]
+
+    valid_params = set(FFDHE_PARAMETERS[i] for i in group_names)
+
+    conversations = {}
+
+    conversation = Connect(host, port)
+    node = conversation
+    ext = {ExtensionType.renegotiation_info: None}
+    ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+               CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA,
+               CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+               CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA256]
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.
+                                                        renegotiation_info:None}))
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectServerKeyExchange())
+    node = node.add_child(ExpectServerHelloDone())
+    node = node.add_child(ClientKeyExchangeGenerator())
+    node = node.add_child(ChangeCipherSpecGenerator())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+    node = node.add_child(ExpectApplicationData())
+    node = node.add_child(AlertGenerator(AlertLevel.warning,
+                                         AlertDescription.close_notify))
+    node = node.add_child(ExpectAlert(AlertLevel.warning,
+                                      AlertDescription.close_notify))
+    node.next_sibling = ExpectClose()
+    node.add_child(ExpectClose())
+
+    conversations["sanity"] = conversation
+
+    conversation = Connect(host, port)
+    node = conversation
+    ext = {ExtensionType.renegotiation_info: None}
+    ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+               CipherSuite.TLS_DHE_RSA_WITH_AES_256_CBC_SHA,
+               CipherSuite.TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+               CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA256]
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
+    node = node.add_child(ClientHelloGenerator(ciphers, extensions=ext))
+    node = node.add_child(ExpectServerHello(extensions={ExtensionType.
+                                                        renegotiation_info:None}))
+    node = node.add_child(ExpectCertificate())
+    node = node.add_child(ExpectServerKeyExchange(valid_params=valid_params))
+    node = node.add_child(ExpectServerHelloDone())
+    node = node.add_child(ClientKeyExchangeGenerator())
+    node = node.add_child(ChangeCipherSpecGenerator())
+    node = node.add_child(FinishedGenerator())
+    node = node.add_child(ExpectChangeCipherSpec())
+    node = node.add_child(ExpectFinished())
+    node = node.add_child(ApplicationDataGenerator(
+        bytearray(b"GET / HTTP/1.0\r\n\r\n")))
+    node = node.add_child(ExpectApplicationData())
+    node = node.add_child(AlertGenerator(AlertLevel.warning,
+                                         AlertDescription.close_notify))
+    node = node.add_child(ExpectAlert(AlertLevel.warning,
+                                      AlertDescription.close_notify))
+    node.next_sibling = ExpectClose()
+    node.add_child(ExpectClose())
+
+    conversations["FFDH parameters check"] = conversation
+
+    good = 0
+    bad = 0
+    xfail = 0
+    xpass = 0
+    failed = []
+    xpassed = []
+    num_limit = num_limit or len(conversations)
+
+    # make sure that sanity test is run first and last
+    # to verify that server was running and kept running throughout
+    sanity_tests = [('sanity', conversations['sanity'])]
+    if run_only:
+        if num_limit > len(run_only):
+            num_limit = len(run_only)
+        regular_tests = [(k, v) for k, v in conversations.items() if
+                         k in run_only]
+    else:
+        regular_tests = [(k, v) for k, v in conversations.items() if
+                         (k != 'sanity') and k not in run_exclude]
+    sampled_tests = sample(regular_tests, min(num_limit, len(regular_tests)))
+    ordered_tests = chain(sanity_tests, sampled_tests, sanity_tests)
+
+    for c_name, c_test in ordered_tests:
+        if run_only and c_name not in run_only or c_name in run_exclude:
+            continue
+        print("{0} ...".format(c_name))
+
+        runner = Runner(c_test)
+
+        res = True
+        exception = None
+        try:
+            runner.run()
+        except Exception as exp:
+            exception = exp
+            print("Error while processing")
+            print(traceback.format_exc())
+            res = False
+
+        if c_name in expected_failures:
+            if res:
+                xpass += 1
+                xpassed.append(c_name)
+                print("XPASS-expected failure but test passed\n")
+            else:
+                if expected_failures[c_name] is not None and \
+                        expected_failures[c_name] not in str(exception):
+                    bad += 1
+                    failed.append(c_name)
+                    print("Expected error message: {0}\n"
+                          .format(expected_failures[c_name]))
+                else:
+                    xfail += 1
+                    print("OK-expected failure\n")
+        else:
+            if res:
+                good += 1
+                print("OK\n")
+            else:
+                bad += 1
+                failed.append(c_name)
+
+    print("Test to check if server selects the expected DH parameters")
+    print("See tlslite.mathtls.FFDHE_PARAMETERS for supported names\n")
+
+    print("Test end")
+    print(20 * '=')
+    print("version: {0}".format(version))
+    print(20 * '=')
+    print("TOTAL: {0}".format(len(sampled_tests) + 2*len(sanity_tests)))
+    print("SKIP: {0}".format(len(run_exclude.intersection(conversations.keys()))))
+    print("PASS: {0}".format(good))
+    print("XFAIL: {0}".format(xfail))
+    print("FAIL: {0}".format(bad))
+    print("XPASS: {0}".format(xpass))
+    print(20 * '=')
+    sort = sorted(xpassed, key=natural_sort_keys)
+    if sort:
+        print("XPASSED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
+    sort = sorted(failed, key=natural_sort_keys)
+    if sort:
+        print("FAILED:\n\t{0}".format('\n\t'.join(repr(i) for i in sort)))
+
+    if bad > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -3293,6 +3293,80 @@ class TestExpectServerKeyExchange(unittest.TestCase):
         with self.assertRaises(AssertionError):
             exp.process(state, msg)
 
+    def test_process_with_specific_parameters(self):
+        exp = ExpectServerKeyExchange(valid_params=[goodGroupParameters[0]])
+
+        state = ConnectionState()
+        state.cipher = CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+
+        cert = Certificate(CertificateType.x509).\
+                create(X509CertChain([X509().parse(srv_raw_certificate)]))
+
+        private_key = parsePEMKey(srv_raw_key, private=True)
+        client_hello = ClientHello()
+        client_hello.client_version = (3, 3)
+        client_hello.random = bytearray(32)
+        client_hello.extensions = []
+        state.client_random = client_hello.random
+        state.handshake_messages.append(client_hello)
+        server_hello = ServerHello()
+        server_hello.server_version = (3, 3)
+        server_hello.random = bytearray(32)
+        state.server_random = server_hello.random
+        # server hello is not necessary for the test to work
+        #state.handshake_messages.append(server_hello)
+        state.handshake_messages.append(cert)
+        srv_key_exchange = DHE_RSAKeyExchange(
+                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+                client_hello,
+                server_hello,
+                private_key,
+                dhParams=goodGroupParameters[0])
+
+        msg = srv_key_exchange.makeServerKeyExchange('sha1')
+
+        exp.process(state, msg)
+
+    def test_process_with_unexpected_parameters(self):
+        exp = ExpectServerKeyExchange(valid_params=[goodGroupParameters[0]])
+
+        state = ConnectionState()
+        state.cipher = CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+
+        cert = Certificate(CertificateType.x509).\
+                create(X509CertChain([X509().parse(srv_raw_certificate)]))
+
+        private_key = parsePEMKey(srv_raw_key, private=True)
+        client_hello = ClientHello()
+        client_hello.client_version = (3, 3)
+        client_hello.random = bytearray(32)
+        client_hello.extensions = []
+        state.client_random = client_hello.random
+        state.handshake_messages.append(client_hello)
+        server_hello = ServerHello()
+        server_hello.server_version = (3, 3)
+        server_hello.random = bytearray(32)
+        state.server_random = server_hello.random
+        # server hello is not necessary for the test to work
+        #state.handshake_messages.append(server_hello)
+        state.handshake_messages.append(cert)
+        srv_key_exchange = DHE_RSAKeyExchange(
+                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+                client_hello,
+                server_hello,
+                private_key,
+                dhParams=goodGroupParameters[1])
+
+        msg = srv_key_exchange.makeServerKeyExchange('sha1')
+
+        with self.assertRaises(AssertionError):
+            exp.process(state, msg)
+
+    def test_with_mutually_exclusive_dh_settings(self):
+        with self.assertRaises(ValueError):
+            ExpectServerKeyExchange(valid_params=[goodGroupParameters[0]],
+                                    valid_groups=[255])
+
 
 class TestExpectCertificateRequest(unittest.TestCase):
     def test___init__(self):

--- a/tests/test_tlsfuzzer_expect.py
+++ b/tests/test_tlsfuzzer_expect.py
@@ -3359,8 +3359,47 @@ class TestExpectServerKeyExchange(unittest.TestCase):
 
         msg = srv_key_exchange.makeServerKeyExchange('sha1')
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(AssertionError) as e:
             exp.process(state, msg)
+
+        self.assertIn("RFC5054 group 2", str(e.exception))
+
+    def test_process_with_unrecognised_parameters(self):
+        exp = ExpectServerKeyExchange(valid_params=[goodGroupParameters[0]])
+
+        state = ConnectionState()
+        state.cipher = CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+
+        cert = Certificate(CertificateType.x509).\
+                create(X509CertChain([X509().parse(srv_raw_certificate)]))
+
+        private_key = parsePEMKey(srv_raw_key, private=True)
+        client_hello = ClientHello()
+        client_hello.client_version = (3, 3)
+        client_hello.random = bytearray(32)
+        client_hello.extensions = []
+        state.client_random = client_hello.random
+        state.handshake_messages.append(client_hello)
+        server_hello = ServerHello()
+        server_hello.server_version = (3, 3)
+        server_hello.random = bytearray(32)
+        state.server_random = server_hello.random
+        # server hello is not necessary for the test to work
+        #state.handshake_messages.append(server_hello)
+        state.handshake_messages.append(cert)
+        srv_key_exchange = DHE_RSAKeyExchange(
+                CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
+                client_hello,
+                server_hello,
+                private_key,
+                dhParams=(0xabc, goodGroupParameters[1][1]))
+
+        msg = srv_key_exchange.makeServerKeyExchange('sha1')
+
+        with self.assertRaises(AssertionError) as e:
+            exp.process(state, msg)
+
+        self.assertIn("g:0xabc", str(e.exception))
 
     def test_with_mutually_exclusive_dh_settings(self):
         with self.assertRaises(ValueError):

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -128,6 +128,8 @@
          {"name" : "test-fallback-scsv.py",
           "arguments" : ["--tls-1.3", "-d"]
          },
+         {"name" : "test-ffdhe-expected-params.py",
+          "arguments" : ["--named-ffdh", "RFC5054 group 3"]},
          {"name" : "test-ffdhe-negotiation.py"},
          {"name" : "test-fuzzed-ciphertext.py"},
          {"name" : "test-fuzzed-finished.py"},

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -128,6 +128,8 @@
          {"name" : "test-fallback-scsv.py",
           "arguments" : ["--tls-1.3", "-d"]
          },
+         {"name" : "test-ffdhe-expected-params.py",
+          "arguments" : ["--named-ffdh", "RFC5054 group 3"]},
          {"name" : "test-ffdhe-negotiation.py"},
          {"name" : "test-fuzzed-ciphertext.py"},
          {"name" : "test-fuzzed-finished.py"},

--- a/tlsfuzzer/expect.py
+++ b/tlsfuzzer/expect.py
@@ -1042,6 +1042,14 @@ class ExpectServerKeyExchange(ExpectHandshake):
 
     def __init__(self, version=None, cipher_suite=None, valid_sig_algs=None,
                  valid_groups=None):
+        """
+        Expect ServerKeyExchange message from server.
+
+        :param list(int) valid_groups: TLS group identifiers for groups that
+            server can use. In case the groups include identifiers between 256
+            and 512 (see RFC 7919), the node will also check that the server
+            selected FFDH parameters match the parameters specified in the RFC.
+        """
         msg_type = HandshakeType.server_key_exchange
         super(ExpectServerKeyExchange, self).__init__(ContentType.handshake,
                                                       msg_type)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Add features and test to verify that server selected specific DH prime and generator

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
Ensuring that servers working in FIPS mode select only parameters from allowed set

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [x] required version of tlslite-ng updated in requirements.txt and README.md

Depends on https://github.com/tomato42/tlslite-ng/pull/412

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/668)
<!-- Reviewable:end -->
