### PR TITLE
Find python binary dynamically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY : default
+PYTHON=$(or $(shell which python3),$(shell which python))
 default:
 	@echo "To install run \"./setup.py install\" or \"make install\""
 	@echo "To test sanity of code run \"make test\""
@@ -14,7 +15,7 @@ clean:
 
 .PHONY : install
 install:
-	./setup.py install
+	"$(PYTHON)" setup.py install
 
 .PHONY : docs
 docs:
@@ -26,11 +27,11 @@ test: docs
 	coverage3 report -m
 	coverage3 xml
 	coverage3 html
-	python tests/verify-scripts-json.py tests/tlslite-ng.json tests/tlslite-ng-random-subset.json
+	"$(PYTHON)" tests/verify-scripts-json.py tests/tlslite-ng.json tests/tlslite-ng-random-subset.json
 	pylint --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" tlsfuzzer > pylint_report.txt || :
 	diff-quality --violations=pylint --fail-under=90 pylint_report.txt
 	diff-cover --fail-under=90 coverage.xml
 
 test-scripts:
-	python tests/verify-scripts-json.py tests/tlslite-ng.json tests/tlslite-ng-random-subset.json
-	python tests/scripts_retention.py tests/tlslite-ng.json `which tls.py` 1850
+	"$(PYTHON)" tests/verify-scripts-json.py tests/tlslite-ng.json tests/tlslite-ng-random-subset.json
+	"$(PYTHON)" tests/scripts_retention.py tests/tlslite-ng.json ../tlslite-ng/scripts/tls.py 1850

--- a/tests/scripts_retention.py
+++ b/tests/scripts_retention.py
@@ -148,7 +148,7 @@ def run_clients(tests, common_args, srv, expected_size):
         script = params["name"]
         logger.info("{0}:started".format(script))
         start_time = time.time()
-        proc_args = ['python', '-u',
+        proc_args = [sys.executable, '-u',
                      'scripts/{0}'.format(script)]
         arguments = params.get("arguments", [])
         arguments = [expected_size if arg == "{expected_size}" else arg for
@@ -196,6 +196,10 @@ def run_with_json(config_file, srv_path, expected_size):
 
     for srv_conf in config:
         command = srv_conf["server_command"]
+        for number, value in enumerate(command):
+            if value == '{python}':
+                command[number] = sys.executable
+                break
         for number, value in enumerate(command):
             if value == "{command}":
                 command[number] = srv_path

--- a/tests/tlslite-ng-random-subset.json
+++ b/tests/tlslite-ng-random-subset.json
@@ -1,5 +1,5 @@
 [
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--cipherlist", "chacha20-poly1305",
@@ -324,7 +324,7 @@
          {"name" : "test-zero-length-data.py"}
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--reqcert", "localhost:4433"],
@@ -374,7 +374,7 @@
           }
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--ssl3",
@@ -392,7 +392,7 @@
          {"name" : "test-SSLv3-padding.py"}
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "--psk", "aa",
                  "--psk-ident", "test",
                  "localhost:4433"],
@@ -405,7 +405,7 @@
          {"name" : "test-tls13-psk_dhe_ke.py"}
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "--psk", "aa",
                  "--psk-ident", "test",
                  "--psk-sha384",
@@ -420,7 +420,7 @@
          {"name" : "test-tls13-psk_dhe_ke.py"}
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverRSAPSSKey.pem",
                  "-c", "tests/serverRSAPSSCert.pem",
                  "localhost:4433"],
@@ -437,7 +437,7 @@
         }
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--max-ver", "tls1.2",
@@ -457,7 +457,7 @@
          {"name" : "test-tls13-non-support.py"}
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--request-pha",
@@ -472,7 +472,7 @@
          }
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--require-pha",
@@ -489,7 +489,7 @@
          }
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                 "-c", "tests/serverECCert.pem",
                 "-k", "tests/serverECKey.pem",
                 "-c", "tests/serverP384ECCert.pem",

--- a/tests/tlslite-ng.json
+++ b/tests/tlslite-ng.json
@@ -1,5 +1,5 @@
 [
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--cipherlist", "chacha20-poly1305",
@@ -320,7 +320,7 @@
          {"name" : "test-zero-length-data.py"}
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--reqcert", "localhost:4433"],
@@ -370,7 +370,7 @@
           }
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--ssl3",
@@ -386,7 +386,7 @@
          {"name" : "test-SSLv3-padding.py"}
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "--psk", "aa",
                  "--psk-ident", "test",
                  "localhost:4433"],
@@ -399,7 +399,7 @@
          {"name" : "test-tls13-psk_dhe_ke.py"}
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "--psk", "aa",
                  "--psk-ident", "test",
                  "--psk-sha384",
@@ -414,7 +414,7 @@
          {"name" : "test-tls13-psk_dhe_ke.py"}
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverRSAPSSKey.pem",
                  "-c", "tests/serverRSAPSSCert.pem",
                  "localhost:4433"],
@@ -431,7 +431,7 @@
 	}
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--max-ver", "tls1.2",
@@ -451,7 +451,7 @@
          {"name" : "test-tls13-non-support.py"}
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--request-pha",
@@ -466,7 +466,7 @@
          }
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                  "-k", "tests/serverX509Key.pem",
                  "-c", "tests/serverX509Cert.pem",
                  "--require-pha",
@@ -483,7 +483,7 @@
          }
      ]
     },
-    {"server_command": ["python", "-u", "{command}", "server",
+    {"server_command": ["{python}", "-u", "{command}", "server",
                 "-k", "tests/serverECKey.pem",
                 "-c", "tests/serverECCert.pem",
                 "--cipherlist", "chacha20-poly1305",


### PR DESCRIPTION
Some systems have a suitable Python interpreter, but not under the expected `python` binary name. E.g. on Debian(-ish) systems the Python 3 interpreter is called `python3`. This PR aims to support both.

### Description
* The `Makefile` now searches for both `python3` and `python` (using `which`), and uses the first one found.
* `tests/scripts_retention.py` uses `sys.executable` instead of hardcoded `'python'`. That should work completely independent of the platform.

### Motivation and Context
Fixes #670 

### Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/671)
<!-- Reviewable:end -->
