### PR TITLE
Fix incorrect indentation

### DIFF
--- a/scripts/test-openssl-3712.py
+++ b/scripts/test-openssl-3712.py
@@ -187,7 +187,7 @@ def main():
             print(traceback.format_exc())
             res = False
 
-         if c_name in expected_failures:
+        if c_name in expected_failures:
             if res:
                 xpass += 1
                 xpassed.append(c_name)
@@ -202,7 +202,7 @@ def main():
                 else:
                     xfail += 1
                     print("OK-expected failure\n")
-         else:
+        else:
             if res:
                 good += 1
                 print("OK\n")


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

Two lines are incorrectly indented leading to

```shell
$ python3 scripts/test-openssl-3712.py
  File "scripts/test-openssl-3712.py", line 190
    if c_name in expected_failures:
                                  ^
IndentationError: unindent does not match any outer indentation level
```
### Description
<!-- Describe your changes in detail below -->

Unindented said two lines (lines 190 and 205).

### Motivation and Context

Make the script runnable again. The bug was introduced in ffd7a1bd73a0185dc23be0942766ffe5bf42ba12.
### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/672)
<!-- Reviewable:end -->
