### PR TITLE
fixup ordered_dict for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,12 @@ jobs:
    - python: 3.8
      dist: xenial
      sudo: true
+   - python: 3.9-dev
+     dist: xenial
+     sudo: true
+   - python: nightly
+     dist: xenial
+     sudo: true
 # ANALYSIS_DEP=false EXTRACT_DEP=true
    - python: 2.6
      env: EXTRACT_DEP=true
@@ -52,6 +58,14 @@ jobs:
      dist: xenial
      sudo: true
      env: EXTRACT_DEP=true
+   - python: 3.9-dev
+     dist: xenial
+     sudo: true
+     env: EXTRACT_DEP=true
+   - python: nightly
+     dist: xenial
+     sudo: true
+     env: EXTRACT_DEP=true
 # ANALYSIS_DEP=true EXTRACT_DEP=false
    - python: 3.6
      env: ANALYSIS_DEP=true
@@ -60,6 +74,14 @@ jobs:
      sudo: true
      env: ANALYSIS_DEP=true
    - python: 3.8
+     dist: xenial
+     sudo: true
+     env: ANALYSIS_DEP=true
+   - python: 3.9-dev
+     dist: xenial
+     sudo: true
+     env: ANALYSIS_DEP=true
+   - python: nightly
      dist: xenial
      sudo: true
      env: ANALYSIS_DEP=true
@@ -73,6 +95,22 @@ jobs:
    - python: 3.8
      dist: xenial
      sudo: true
+     env: ANALYSIS_DEP=true EXTRACT_DEP=true CC_REPORT=true
+   - python: 3.9-dev
+     dist: xenial
+     sudo: true
+     env: ANALYSIS_DEP=true EXTRACT_DEP=true CC_REPORT=true
+   - python: nightly
+     dist: xenial
+     sudo: true
+     env: ANALYSIS_DEP=true EXTRACT_DEP=true CC_REPORT=true
+ allow_failures:
+   # lazy-object-proxy fails to build
+   - python: nightly
+   # scipy fails to build
+   - python: 3.9-dev
+     env: ANALYSIS_DEP=true
+   - python: 3.9-dev
      env: ANALYSIS_DEP=true EXTRACT_DEP=true CC_REPORT=true
 
 branches:
@@ -129,11 +167,18 @@ script:
   # check if all scripts are included in the json files
   - python tests/verify-scripts-json.py tests/tlslite-ng-random-subset.json tests/tlslite-ng.json
   # the HTTP header includes python version, since "2.7.15" is longer than "2.6.9", the reply itself is longer too
+  # more generally, it should be `1845 + len(sys.version.split()[0])`,
+  # as http.server uses `sys_version = "Python/" + sys.version.split()[0]`
+  # https://github.com/python/cpython/blob/2c050e52f1ccf5db03819e4ed70690521d67e9fa/Lib/http/server.py#L253
   - |
       if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then
         export REPLY_SIZE=1850
+      elif [[ $TRAVIS_PYTHON_VERSION == '3.9-dev' ]]; then
+        export REPLY_SIZE=1853  # Server: SimpleHTTP/0.6 Python/3.9.0rc1+
+      elif [[ $TRAVIS_PYTHON_VERSION == 'nightly' ]]; then
+        export REPLY_SIZE=1852  # Server: SimpleHTTP/0.6 Python/3.10.0a0
       else
-        export REPLY_SIZE=1849
+        export REPLY_SIZE=1849  # Server: SimpleHTTP/0.6 Python/3.7.6
       fi
   - travis_wait 30 python tests/scripts_retention.py tests/tlslite-ng-random-subset.json `which tls.py` $REPLY_SIZE
   # pylint doesn't work on 2.6: https://bitbucket.org/logilab/pylint/issue/390/py26-compatiblity-broken

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY : default
 PYTHON=$(or $(shell which python3),$(shell which python))
+EXPECTED_SIZE=$(shell $(PYTHON) -c 'import sys; print(1845 + len(sys.version.split()[0]))')
 default:
 	@echo "To install run \"./setup.py install\" or \"make install\""
 	@echo "To test sanity of code run \"make test\""
@@ -34,4 +35,4 @@ test: docs
 
 test-scripts:
 	"$(PYTHON)" tests/verify-scripts-json.py tests/tlslite-ng.json tests/tlslite-ng-random-subset.json
-	"$(PYTHON)" tests/scripts_retention.py tests/tlslite-ng.json ../tlslite-ng/scripts/tls.py 1850
+	"$(PYTHON)" tests/scripts_retention.py tests/tlslite-ng.json ../tlslite-ng/scripts/tls.py $(EXPECTED_SIZE)

--- a/tlsfuzzer/utils/ordered_dict.py
+++ b/tlsfuzzer/utils/ordered_dict.py
@@ -8,9 +8,12 @@ try:
     from thread import get_ident as _get_ident
 except ImportError:
     try:
-        from dummy_thread import get_ident as _get_ident
+        from _thread import get_ident as _get_ident
     except ImportError:
-        from _dummy_thread import get_ident as _get_ident
+        try:
+            from dummy_thread import get_ident as _get_ident
+        except ImportError:
+            from _dummy_thread import get_ident as _get_ident
 
 try:
     from _abcoll import KeysView, ValuesView, ItemsView


### PR DESCRIPTION
On current Rawhide / Python 3.9 some of the tests fail because `get_ident` has moved again.

### Description
<!-- Describe your changes in detail below -->

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/678)
<!-- Reviewable:end -->
