### PR TITLE
Send sigalg extensions otherwise it defaults to sha1

### DIFF
--- a/scripts/test-dhe-rsa-key-exchange-with-bad-messages.py
+++ b/scripts/test-dhe-rsa-key-exchange-with-bad-messages.py
@@ -25,6 +25,9 @@ from tlsfuzzer.expect import ExpectServerHello, ExpectCertificate, \
 from tlslite.constants import CipherSuite, AlertLevel, AlertDescription, \
         ExtensionType
 from tlsfuzzer.utils.lists import natural_sort_keys
+from tlslite.extensions import SignatureAlgorithmsExtension, \
+        SignatureAlgorithmsCertExtension
+from tlsfuzzer.helpers import RSA_SIG_ALL
 
 version = 2
 
@@ -98,10 +101,15 @@ def main():
 
     conversation = Connect(host, port)
     node = conversation
+    ext = {}
+    ext[ExtensionType.renegotiation_info] = None
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.
-                                                   renegotiation_info:None}))
+                                               extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
                                                      renegotiation_info:None}))
     node = node.add_child(ExpectCertificate())
@@ -128,10 +136,15 @@ def main():
     for i in [8*1024]:
         conversation = Connect(host, port)
         node = conversation
+        ext = {}
+        ext[ExtensionType.renegotiation_info] = None
+        ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
         ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
         node = node.add_child(ClientHelloGenerator(ciphers,
-                                                   extensions={ExtensionType.
-                                                       renegotiation_info:None}))
+                                                   extensions=ext))
         node = node.add_child(ExpectServerHello(extensions={ExtensionType.
                                                          renegotiation_info:None}))
         node = node.add_child(ExpectCertificate())
@@ -152,10 +165,15 @@ def main():
     for i in [0, 1]:
         conversation = Connect(host, port)
         node = conversation
+        ext = {}
+        ext[ExtensionType.renegotiation_info] = None
+        ext[ExtensionType.signature_algorithms] = \
+            SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
+        ext[ExtensionType.signature_algorithms_cert] = \
+            SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
         ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
         node = node.add_child(ClientHelloGenerator(ciphers,
-                                                   extensions={ExtensionType.
-                                                       renegotiation_info:None}))
+                                                   extensions=ext))
         node = node.add_child(ExpectServerHello(extensions={ExtensionType.
                                                          renegotiation_info:None}))
         node = node.add_child(ExpectCertificate())
@@ -176,10 +194,15 @@ def main():
     # share equal to p
     conversation = Connect(host, port)
     node = conversation
+    ext = {}
+    ext[ExtensionType.renegotiation_info] = None
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.
-                                                   renegotiation_info:None}))
+                                               extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
                                                      renegotiation_info:None}))
     node = node.add_child(ExpectCertificate())
@@ -200,10 +223,15 @@ def main():
     # share equal to p-1
     conversation = Connect(host, port)
     node = conversation
+    ext = {}
+    ext[ExtensionType.renegotiation_info] = None
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.
-                                                   renegotiation_info:None}))
+                                               extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
                                                      renegotiation_info:None}))
     node = node.add_child(ExpectCertificate())
@@ -224,10 +252,15 @@ def main():
     # truncated dh_Yc value
     conversation = Connect(host, port)
     node = conversation
+    ext = {}
+    ext[ExtensionType.renegotiation_info] = None
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.
-                                                   renegotiation_info:None}))
+                                               extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
                                                      renegotiation_info:None}))
     node = node.add_child(ExpectCertificate())
@@ -249,10 +282,15 @@ def main():
     # padded Client Key Exchange
     conversation = Connect(host, port)
     node = conversation
+    ext = {}
+    ext[ExtensionType.renegotiation_info] = None
+    ext[ExtensionType.signature_algorithms] = \
+        SignatureAlgorithmsExtension().create(RSA_SIG_ALL)
+    ext[ExtensionType.signature_algorithms_cert] = \
+        SignatureAlgorithmsCertExtension().create(RSA_SIG_ALL)
     ciphers = [CipherSuite.TLS_DHE_RSA_WITH_AES_128_CBC_SHA]
     node = node.add_child(ClientHelloGenerator(ciphers,
-                                               extensions={ExtensionType.
-                                                   renegotiation_info:None}))
+                                               extensions=ext))
     node = node.add_child(ExpectServerHello(extensions={ExtensionType.
                                                      renegotiation_info:None}))
     node = node.add_child(ExpectCertificate())


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Send signature algorithm extensions otherwise it falls back to sha1 and the script fails in FIPS mode.
### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [ ] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [x] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/688)
<!-- Reviewable:end -->
