### PR TITLE
fix conf_interval_plot.png with new matplotlib

### DIFF
--- a/build-requirements-analysis.txt
+++ b/build-requirements-analysis.txt
@@ -1,4 +1,4 @@
 numpy>=1.15.0
 scipy
-matplotlib
+matplotlib>=3.3.2
 pandas

--- a/requirements-timing.txt
+++ b/requirements-timing.txt
@@ -1,5 +1,5 @@
 dpkt>=1.9.2
 numpy>=1.15.0
 scipy
-matplotlib
+matplotlib>=3.3.2
 pandas

--- a/tlsfuzzer/analysis.py
+++ b/tlsfuzzer/analysis.py
@@ -397,7 +397,7 @@ class Analysis(object):
         fig = Figure(figsize=(16, 12))
         canvas = FigureCanvas(fig)
         ax = fig.add_subplot(1, 1, 1)
-        ax.violinplot(data.T, widths=0.7, showmeans=True, showextrema=True)
+        ax.violinplot(data, widths=0.7, showmeans=True, showextrema=True)
         ax.set_xticks(list(range(len(data.columns)+1)))
         ax.set_xticklabels([' '] + list(data.columns))
         formatter = mpl.ticker.EngFormatter('s')


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Fixes the bug where conf_interval_plot.png would show just one "violin" (graph)

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
bug/incompatibility with new matplotlib

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [ ] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [ ] new and modified scripts were ran against popular TLS implementations:
  - [ ] OpenSSL
  - [ ] NSS
  - [ ] GnuTLS
- [ ] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/704)
<!-- Reviewable:end -->
