### PR TITLE
report progress once every two seconds, provide ETA

### DIFF
--- a/tests/test_tlsfuzzer_timing_runner.py
+++ b/tests/test_tlsfuzzer_timing_runner.py
@@ -220,3 +220,16 @@ class TestRunner(unittest.TestCase):
                                 with mock.patch('tlsfuzzer.timing_runner.Runner') as runner:
                                     runner.return_value.run.side_effect = raise_error
                                     self.assertRaises(AssertionError, self.runner.run)
+
+    def test__format_seconds_with_seconds(self):
+        self.assertEqual(TimingRunner._format_seconds(12.5), "12.50s")
+
+    def test__format_seconds_with_minutes(self):
+        self.assertEqual(TimingRunner._format_seconds(60*35), "35m 0.00s")
+
+    def test__format_seconds_with_hours(self):
+        self.assertEqual(TimingRunner._format_seconds(60*60), "1h 0m 0.00s")
+
+    def test__format_seconds_with_days(self):
+        self.assertEqual(TimingRunner._format_seconds(24*60*60*2),
+                         "2d 0h 0m 0.00s")


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
change frequency and contents of the printed status line when running timing tests

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
for a fast system, reporting status every 20 connections is
actually quite a lot of printing, so upgrade to using a thread
that keeps the status of the progress and reports more detailed
statistics, including current rate and estimated time of completion

Old status:
```
Done:  15.14%
```
New status:
```
Done:  15.14%, elapsed: 2m 44.16s, speed: 242.00conn/s, avg speed: 240.07conn/s, remaining: 15m 19.89s, ETA: 21:14:25 14-10-2020
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [x] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [x] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/711)
<!-- Reviewable:end -->
