### PR TITLE
add support for writing to socket directly

### DIFF
--- a/docs/source/modifying-messages.rst
+++ b/docs/source/modifying-messages.rst
@@ -46,6 +46,11 @@ You can find a usage example in:
     If you want to send an otherwise valid message, only as plaintext, not
     encrypted, see the :ref:`clearing-encryption-settings` section.
 
+To write directly to the socket, without record layer encapsulation,
+use the :py:class:`~tlsfuzzer.messages.RawSocketWriteGenerator`.
+It accepts two parameters, one to specify the data to write and another,
+optional, used for debugging, the ``description``.
+
 Creating arbitrary messages
 ---------------------------
 

--- a/tlsfuzzer/messages.py
+++ b/tlsfuzzer/messages.py
@@ -376,6 +376,33 @@ class CopyVariables(Command):
                 val.append(state.key[name])
 
 
+class RawSocketWriteGenerator(Command):
+    """
+    Send a plaintext data irrespective of encryption state.
+
+    Does not update handshake hashes, record layer state, does not fragment,
+    etc.
+
+    :ivar bytearray ~.data: data to send
+    :ivar str ~.description: identifier to print when processing of the node
+        fails
+    """
+
+    def __init__(self, data, description=None):
+        """Set the record layer type and payload to send."""
+        super(RawSocketWriteGenerator, self).__init__()
+        self.data = data
+        self.description = description
+
+    def __repr__(self):
+        """Return human readable representation of the object."""
+        return self._repr(["data", "description"])
+
+    def process(self, state):
+        """Send the message over the socket."""
+        state.msg_sock._recordSocket.sock.send(self.data)
+
+
 class PlaintextMessageGenerator(Command):
     """
     Send a plaintext data record irrespective of encryption state.


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Add ability to write raw bytes to the socket directly, without wrapping it into record layer

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->

All the existing Generator nodes don't allow for skipping the record layer header. While it's not a problem for fuzzing TLS, it does not allow for testing servers that require STARTTLS-like commands. Sometimes it's also easier to write garbage to
socket directly than to depend on fuzzers to modify record layer header.

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
- [x] all new and existing tests pass (see Travis CI results)
- [ ] [test script checklist](https://github.com/tomato42/tlsfuzzer/wiki/Test-script-checklist) was followed for new scripts
- [ ] new test script added to `tlslite-ng.json` and `tlslite-ng-random-subset.json`
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/716)
<!-- Reviewable:end -->
