### PR TITLE
run the cc-test-reporter on one runner only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,15 +99,16 @@ jobs:
    - python: 3.8
      dist: xenial
      sudo: true
+     # Note: CC_REPORT=true can be set in only one environment
      env: ANALYSIS_DEP=true EXTRACT_DEP=true CC_REPORT=true
    - python: 3.9
      dist: xenial
      sudo: true
-     env: ANALYSIS_DEP=true EXTRACT_DEP=true CC_REPORT=true
+     env: ANALYSIS_DEP=true EXTRACT_DEP=true
    - python: nightly
      dist: xenial
      sudo: true
-     env: ANALYSIS_DEP=true EXTRACT_DEP=true CC_REPORT=true
+     env: ANALYSIS_DEP=true EXTRACT_DEP=true
  allow_failures:
    # lazy-object-proxy fails to build
    - python: nightly
@@ -115,7 +116,7 @@ jobs:
    - python: 3.9
      env: ANALYSIS_DEP=true
    - python: 3.9
-     env: ANALYSIS_DEP=true EXTRACT_DEP=true CC_REPORT=true
+     env: ANALYSIS_DEP=true EXTRACT_DEP=true
 
 branches:
   only:


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail below -->
Run the codeclimate status reporter on one configuration only

### Motivation and Context
<!-- Describe why the change is introduced, if it solves an issue add "fixes #1"
with a correct number -->
once py3.9 starts passing, the report from codeclimate will be incorrect, fix it before that

### Checklist
<!-- go over following points. check them with an `x` if they do apply,
(they turn into clickable checkboxes once the PR is submitted, so no need
to do everything at once)

if you're unsure about any of those items, just ask in comment to PR

if the PR resolves an issue, please add further checkboxes that describe the
action items or test scenarios from it
-->

- [x] I have read the [CONTRIBUTING.md](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md) document and my PR follows [change requirements](https://github.com/tomato42/tlsfuzzer/blob/master/CONTRIBUTING.md#change-requirements) therein
- [x] the changes are also reflected in documentation and code comments
  - n/a
- [x] all new and existing tests pass (see Travis CI results)
- [x] new and modified scripts were ran against popular TLS implementations:
  - n/a
- [x] required version of tlslite-ng updated in requirements.txt and README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomato42/tlsfuzzer/725)
<!-- Reviewable:end -->
